### PR TITLE
Fixed issue with shift-clicking to get full RP name

### DIFF
--- a/totalRP3/modules/chatframe/chatframe.lua
+++ b/totalRP3/modules/chatframe/chatframe.lua
@@ -592,7 +592,7 @@ function hooking()
 			local currentCursorPosition = editBox:GetCursorPosition();
 
 			-- Save the text that is before and after the name inserted
-			local textBefore = currentText:sub(1, currentCursorPosition - unitID:len() - 1);
+			local textBefore = currentText:sub(1, currentCursorPosition - unitID:len());
 			local textAfter = currentText:sub(currentCursorPosition+1 );
 
 			local name = getFullnameForUnitUsingChatMethod(unitID, unitID);


### PR DESCRIPTION
There was a small index error causing all sorts of issues.