### PR TITLE
Issue #42 : Fixed NPC speech color after emote or OOC pattern

### DIFF
--- a/totalRP3/modules/chatframe/chatframe.lua
+++ b/totalRP3/modules/chatframe/chatframe.lua
@@ -1,23 +1,31 @@
 ----------------------------------------------------------------------------------
--- Total RP 3
--- Chat management
---	---------------------------------------------------------------------------
---	Copyright 2014 Sylvain Cossement (telkostrasz@telkostrasz.be)
---
---	Licensed under the Apache License, Version 2.0 (the "License");
---	you may not use this file except in compliance with the License.
---	You may obtain a copy of the License at
---
---		http://www.apache.org/licenses/LICENSE-2.0
---
---	Unless required by applicable law or agreed to in writing, software
---	distributed under the License is distributed on an "AS IS" BASIS,
---	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
---	See the License for the specific language governing permissions and
---	limitations under the License.
+--- Total RP 3
+--- Chat management
+---	---------------------------------------------------------------------------
+---	Copyright 2014 Sylvain Cossement (telkostrasz@telkostrasz.be)
+--- Copyright 2018 Renaud "Ellypse" Parize <ellypse@totalrp3.info> @EllypseCelwe
+---
+---	Licensed under the Apache License, Version 2.0 (the "License");
+---	you may not use this file except in compliance with the License.
+---	You may obtain a copy of the License at
+---
+---		http://www.apache.org/licenses/LICENSE-2.0
+---
+---	Unless required by applicable law or agreed to in writing, software
+---	distributed under the License is distributed on an "AS IS" BASIS,
+---	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+---	See the License for the specific language governing permissions and
+---	limitations under the License.
 ----------------------------------------------------------------------------------
 
+---@type TRP3_API
+local _, TRP3_API = ...;
+
 -- Removed NPC talk prefix option and changed prefix to a hardcoded one (Paul Corlay) [RIP NPC talk prefix option 2014 - 2017]
+
+-- Ellyb imports
+local ColorManager = TRP3_API.Ellyb.ColorManager;
+local Color = TRP3_API.Ellyb.Color;
 
 -- imports
 local Globals, Utils = TRP3_API.globals, TRP3_API.utils;
@@ -115,7 +123,7 @@ local function configOOCDetectionPattern()
 end
 
 local function configOOCDetectionColor()
-	return getColorFromHexadecimalCode(getConfigValue(CONFIG_OOC_COLOR));
+	return Color(getConfigValue(CONFIG_OOC_COLOR));
 end
 
 local function configInsertFullRPName()
@@ -298,15 +306,17 @@ TRP3_API.utils.getCharacterInfoTab = getCharacterInfoTab;
 -- Emote and OOC detection
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
+---@param message string
+---@param NPCEmoteChatColor Color
 local function detectEmoteAndOOC(message, NPCEmoteChatColor)
 
 	local NPCEmoteChatString = "";
 	if NPCEmoteChatColor then
-		NPCEmoteChatString = format("|c%s", NPCEmoteChatColor:GenerateHexColor());
+		NPCEmoteChatString = NPCEmoteChatColor:GetColorCodeStartSequence();
 	end
 
 	if configDoEmoteDetection() and message:find(configEmoteDetectionPattern()) then
-		local chatColor = getChatColorForChannel("EMOTE");
+		local chatColor = ColorManager.getChatColorForChannel("EMOTE");
 		message = message:gsub(configEmoteDetectionPattern(), function(content)
 			return chatColor:WrapTextInColorCode(content) .. NPCEmoteChatString;
 		end);
@@ -333,7 +343,7 @@ local function handleNPCEmote(message)
 	-- Go through all talk types
 	for talkType, talkChannel in pairs(NPC_TALK_PATTERNS) do
 		if message:find(talkType) then
-			local chatColor = getChatColorForChannel(talkChannel);
+			local chatColor = ColorManager.getChatColorForChannel(talkChannel);
 			local name = message:sub(4, message:find(talkType) - 2); -- Isolate the name
 			local content = message:sub(name:len() + 5);
 
@@ -342,7 +352,7 @@ local function handleNPCEmote(message)
 	end
 
 	-- If none was found, we default to emote
-	local chatColor = getChatColorForChannel("MONSTER_EMOTE");
+	local chatColor = ColorManager.getChatColorForChannel("MONSTER_EMOTE");
 	return chatColor:WrapTextInColorCode(message:sub(4)), " ", chatColor;
 end
 

--- a/totalRP3/modules/chatframe/chatframe.lua
+++ b/totalRP3/modules/chatframe/chatframe.lua
@@ -320,7 +320,7 @@ local function detectEmoteAndOOC(message, NPCEmoteChatColor)
 	end
 
 	return message;
-	end
+end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- NPC talk detection


### PR DESCRIPTION
Color was reset after a pattern, which brought back the emote color.
Now sending the color in the pattern detection function if it is an NPC speech, and adding the code back after the pattern.