### PR TITLE
Implement reordering of additional characteristics

### DIFF
--- a/totalRP3/modules/register/characters/register_characteristics.lua
+++ b/totalRP3/modules/register/characters/register_characteristics.lua
@@ -791,6 +791,16 @@ local function onMiscInfoDragStart(handle)
 	local ticker = C_Timer.NewTicker(MISC_INFO_DRAG_UPDATE_PERIOD, onMiscInfoDragUpdate);
 	ticker.handle = handle;
 	handle.miscInfoTicker = ticker;
+
+	-- Stick the icon of the item in question onto the cursor for some feedback.
+	-- Also throw in some sound cues a-la spellbook drag/drop.
+	local node = handle.node;
+	SetCursor(node.Icon.Icon:GetTexture());
+
+	-- For some reason there's no constant for the pickup sound effect
+	-- used by ability icons. Logically this'd be present as
+	-- IG_ABILITY_ICON_PICKUP.
+	PlaySound(837);
 end
 
 --- onMiscInfoDragStop is called when a handle is no longer being dragged.
@@ -806,6 +816,10 @@ local function onMiscInfoDragStop(handle)
 	-- Kill the ticker as we no longer need it.
 	handle.miscInfoTicker:Cancel();
 	handle.miscInfoTicker = nil;
+
+	-- Kill the icon following the cursor.
+	SetCursor(nil);
+	PlaySound(SOUNDKIT.IG_ABILITY_ICON_DROP);
 end
 
 --- setMiscInfoReorderable installs the necessary script handlers to enable

--- a/totalRP3/modules/register/characters/register_characteristics.lua
+++ b/totalRP3/modules/register/characters/register_characteristics.lua
@@ -18,7 +18,7 @@
 ----------------------------------------------------------------------------------
 
 -- imports
-local Globals, Utils, Comm, Events = TRP3_API.globals, TRP3_API.utils, TRP3_API.communication, TRP3_API.events;
+local Globals, Utils, Comm, Events, UI = TRP3_API.globals, TRP3_API.utils, TRP3_API.communication, TRP3_API.events, TRP3_API.ui;
 local stEtN = Utils.str.emptyToNil;
 local stNtE = Utils.str.nilToEmpty;
 local get = TRP3_API.profile.getData;
@@ -800,7 +800,7 @@ local function onMiscInfoDragStart(handle)
 	-- For some reason there's no constant for the pickup sound effect
 	-- used by ability icons. Logically this'd be present as
 	-- IG_ABILITY_ICON_PICKUP.
-	PlaySound(837);
+	UI.misc.playUISound(837);
 end
 
 --- onMiscInfoDragStop is called when a handle is no longer being dragged.
@@ -819,7 +819,7 @@ local function onMiscInfoDragStop(handle)
 
 	-- Kill the icon following the cursor.
 	SetCursor(nil);
-	PlaySound(SOUNDKIT.IG_ABILITY_ICON_DROP);
+	UI.misc.playUISound(SOUNDKIT.IG_ABILITY_ICON_DROP);
 end
 
 --- setMiscInfoReorderable installs the necessary script handlers to enable

--- a/totalRP3/modules/register/characters/register_ui_characteristics.xml
+++ b/totalRP3/modules/register/characters/register_ui_characteristics.xml
@@ -33,12 +33,12 @@
 			</OnLeave>
 		</Scripts>
 	</Button>
-	
+
 	<!-- Register characteristics register line -->
 	<Frame name="TRP3_RegisterCharact_MiscEditLine" virtual="true">
 		<Size x="20" y="40"/>
 		<Frames>
-			<Button name="$parentIcon" inherits="TRP3_IconButton">
+			<Button name="$parentIcon" parentKey="Icon" inherits="TRP3_IconButton">
 				<Anchors>
 					<Anchor point="LEFT" x="30" y="0"/>
 				</Anchors>


### PR DESCRIPTION
Fixes #51.

The list can be reordered while editing the profile by dragging and dropping the icon (we're using that as the handle). The values correctly persist when saved.

The drag/drop operation is immediate, so when you move an item over another it'll take its place rather than waiting for you to release the mouse button. This is a bit simpler to implement, since otherwise we'd need an indicator texture to say where it's going to drop.

In addition, if the additional info fields are near the boundaries of the scroll frame, it'll scroll in the correct direction automatically if you go past them so you can see where you're dragging to.

![d191aab507028c222dd56f227ad31b85 1](https://user-images.githubusercontent.com/287102/36848343-e5ad26a0-1d58-11e8-9376-7b54177168ab.gif)
