### PR TITLE
Map scanner blip colors

### DIFF
--- a/totalRP3/core/impl/globals.lua
+++ b/totalRP3/core/impl/globals.lua
@@ -89,7 +89,31 @@ TRP3_API.globals = {
 	PSYCHO_MAX_VALUE_V2 = 20,
 	PSYCHO_DEFAULT_LEFT_COLOR = Ellyb.Color(255, 140, 26):Freeze(),
 	PSYCHO_DEFAULT_RIGHT_COLOR = Ellyb.Color(32, 208, 249):Freeze(),
-}
+};
+
+--- RELATIONS is a list of (backwards-compatible) relationship IDs.
+local RELATIONS = {
+	UNFRIENDLY = "UNFRIENDLY",
+	NONE = "NONE",
+	NEUTRAL = "NEUTRAL",
+	BUSINESS = "BUSINESS",
+	FRIEND = "FRIEND",
+	LOVE = "LOVE",
+	FAMILY = "FAMILY",
+};
+TRP3_API.globals.RELATIONS = RELATIONS;
+
+--- RELATIONS_ORDER defines a logical ordering for relations.
+local RELATIONS_ORDER = {
+	[RELATIONS.NONE] = 0,
+	[RELATIONS.UNFRIENDLY] = 1,
+	[RELATIONS.NEUTRAL] = 2,
+	[RELATIONS.BUSINESS] = 3,
+	[RELATIONS.FRIEND] = 4,
+	[RELATIONS.LOVE] = 5,
+	[RELATIONS.FAMILY] = 6,
+};
+TRP3_API.globals.RELATIONS_ORDER = RELATIONS_ORDER;
 
 local emptyMeta = {
 	__newindex = function(_, _, _) end

--- a/totalRP3/modules/map/map_markers.lua
+++ b/totalRP3/modules/map/map_markers.lua
@@ -19,6 +19,7 @@
 
 TRP3_API.map = {};
 
+local Ellyb = TRP3_API.Ellyb;
 local Utils, Events, Globals = TRP3_API.utils, TRP3_API.events, TRP3_API.globals;
 local Comm = TRP3_API.communication;
 local setupIconButton = TRP3_API.ui.frame.setupIconButton;
@@ -29,6 +30,9 @@ local CreateFrame = CreateFrame;
 local after = C_Timer.After;
 local playAnimation = TRP3_API.ui.misc.playAnimation;
 local getConfigValue = TRP3_API.configuration.getValue;
+
+-- Ellyb Imports.
+local Color = Ellyb.Color;
 
 local CONFIG_UI_ANIMATIONS = "ui_animations";
 
@@ -58,6 +62,14 @@ local MARKER_NAME_PREFIX = "TRP3_WordMapMarker";
 
 local MAX_DISTANCE_MARKER = math.sqrt(0.5 * 0.5 + 0.5 * 0.5);
 
+--- TOOLTIP_CATEGORY_TEXT_COLOR is the text color used for category headers
+--  in the displayed tooltip.
+local TOOLTIP_CATEGORY_TEXT_COLOR = Color.CreateFromRGBAAsBytes(255, 209, 0);
+
+--- TOOLTIP_CATEGORY_SEPARATOR is a texture string displayed as a separator.
+local TOOLTIP_CATEGORY_SEPARATOR =
+	[[|TInterface\Common\UI-TooltipDivider-Transparent:8:128:0:0:8:8:0:128:0:8:255:255:255|t]];
+
 local function hideAllMarkers()
 	local i = 1;
 	while(_G[MARKER_NAME_PREFIX .. i]) do
@@ -65,6 +77,67 @@ local function hideAllMarkers()
 		marker:Hide();
 		marker.scanLine = nil;
 		i = i + 1;
+	end
+end
+
+--- Temporary table used by writeMarkerTooltipLines when it queries the marker
+--  list for widgets currently under the mouse cursor.
+local markerTooltipEntries = {};
+
+--- Custom sorting function that compares entries. The resulting order is
+--  in order of their category priority (descending), or if equal, their
+--  sortable name equivalent (ascending).
+local function sortMarkerEntries(a, b)
+	local categoryA = a.categoryPriority or -math.huge;
+	local categoryB = b.categoryPriority or -math.huge;
+
+	local nameA = a.sortName or "";
+	local nameB = b.sortName or "";
+
+	return (categoryA > categoryB)
+		or (categoryA == categoryB and nameA < nameB);
+end
+
+--- Writes the required lines for a world map marker tooltip based on the
+--  current location of the cursor.
+local function writeMarkerTooltipLines(tooltip)
+	-- Iterate over the blips in a first pass to build a list of all the
+	-- ones we're mousing over.
+	local index = 1;
+	while(_G[MARKER_NAME_PREFIX .. index]) do
+		local marker = _G[MARKER_NAME_PREFIX .. index];
+		if marker:IsVisible() and marker:IsMouseOver() then
+			tinsert(markerTooltipEntries, marker);
+		end
+		index = index + 1;
+	end
+
+	-- Sort the entries prior to display.
+	table.sort(markerTooltipEntries, sortMarkerEntries);
+
+	-- Tracking variable for our last category inserted into the tip.
+	-- If it changes we'll stick in a separator.
+	local lastCategory = nil;
+
+	-- This layout will put the category status text above entries
+	-- when the type changes. Requires the entries be sorted by category.
+	for i = 1, #markerTooltipEntries do
+		local marker = markerTooltipEntries[i];
+		if marker.categoryName ~= lastCategory then
+			-- If the previous category was nil we assume this is
+			-- the first, so we'll not put a separating border in.
+			if lastCategory ~= nil then
+				tooltip:AddLine(TOOLTIP_CATEGORY_SEPARATOR, 1, 1, 1);
+			end
+
+			tooltip:AddLine(marker.categoryName or "", TOOLTIP_CATEGORY_TEXT_COLOR:GetRGB());
+			lastCategory = marker.categoryName;
+		end
+
+		tooltip:AddLine(marker.scanLine or "", 1, 1, 1);
+
+		-- Wipe the table as we go.
+		markerTooltipEntries[i] = nil;
 	end
 end
 
@@ -81,17 +154,8 @@ local function getMarker(i, tooltip)
 			WorldMapTooltip:SetOwner(self, "ANCHOR_RIGHT", 0, 0);
 			WorldMapTooltip:AddLine(self.tooltip, 1, 1, 1, true);
 
-			local j = 1;
-			while(_G[MARKER_NAME_PREFIX .. j]) do
-				local markerWidget = _G[MARKER_NAME_PREFIX .. j];
-				if markerWidget:IsVisible() and markerWidget:IsMouseOver() then
-					local scanLine = markerWidget.scanLine;
-					if scanLine then
-						WorldMapTooltip:AddLine(scanLine, 1, 1, 1, true);
-					end
-				end
-				j = j + 1;
-			end
+			writeMarkerTooltipLines(WorldMapTooltip);
+
 			WorldMapTooltip:Show();
 		end);
 		marker:SetScript("OnLeave", function()
@@ -142,16 +206,26 @@ end
 local DECORATION_TYPES = {
 	HOUSE = "house",
 	CHARACTER = "character"
-}
+};
 TRP3_API.map.DECORATION_TYPES = DECORATION_TYPES;
 
 local function decorateMarker(marker, decorationType)
+	-- Reset any customisations.
+	marker.Icon:SetAtlas(nil);
+	marker.Icon:SetVertexColor(1, 1, 1, 1);
+
 	if not decorationType or decorationType == DECORATION_TYPES.CHARACTER then
-		marker.Icon:SetTexture("Interface\\Minimap\\OBJECTICONS");
-		marker.Icon:SetTexCoord(0, 0.125, 0, 0.125);
+		if marker.iconColor then
+			marker.Icon:SetAtlas("PlayerPartyBlip");
+			marker.Icon:SetVertexColor(marker.iconColor:GetRGBA());
+		else
+			marker.Icon:SetAtlas("PartyMember");
+		end
+
+		local layer = marker.Icon:GetDrawLayer();
+		marker.Icon:SetDrawLayer(layer, marker.iconSublevel or 0);
 	elseif decorationType == DECORATION_TYPES.HOUSE then
-		marker.Icon:SetTexture("Interface\\Minimap\\POIICONS");
-		marker.Icon:SetTexCoord(0.357143, 0.422, 0, 0.036);
+		marker.Icon:SetAtlas("poi-town");
 	end
 end
 
@@ -164,15 +238,17 @@ local function displayMarkers(structure)
 	local i = 1;
 	for key, entry in pairs(structure.saveStructure) do
 		local marker = getMarker(i, structure.scanTitle);
-		placeMarker(marker, entry.x, entry.y);
 
-		decorateMarker(marker, DECORATION_TYPES.CHARACTER);
-
-		-- Implementation can be adapted by decorator
+		-- Implementation can be adapted by decorator.
+		--
+		-- Do this before the rest so the decorators have more control over
+		-- the resulting display.
 		if structure.scanMarkerDecorator then
 			structure.scanMarkerDecorator(key, entry, marker);
 		end
 
+		placeMarker(marker, entry.x, entry.y);
+		decorateMarker(marker, DECORATION_TYPES.CHARACTER);
 		animateMarker(marker, entry.x, entry.y, structure.noAnim);
 
 		i = i + 1;

--- a/totalRP3/modules/map/map_markers.lua
+++ b/totalRP3/modules/map/map_markers.lua
@@ -210,23 +210,27 @@ local DECORATION_TYPES = {
 TRP3_API.map.DECORATION_TYPES = DECORATION_TYPES;
 
 local function decorateMarker(marker, decorationType)
-	-- Reset any customisations.
-	marker.Icon:SetAtlas(nil);
-	marker.Icon:SetVertexColor(1, 1, 1, 1);
-
-	if not decorationType or decorationType == DECORATION_TYPES.CHARACTER then
-		if marker.iconColor then
-			marker.Icon:SetAtlas("PlayerPartyBlip");
-			marker.Icon:SetVertexColor(marker.iconColor:GetRGBA());
-		else
-			marker.Icon:SetAtlas("PartyMember");
-		end
-
-		local layer = marker.Icon:GetDrawLayer();
-		marker.Icon:SetDrawLayer(layer, marker.iconSublevel or 0);
+	-- Custom atlases on the marker take priority; after that we'll fall
+	-- back to given decoration types.
+	if marker.iconAtlas then
+		marker.Icon:SetAtlas(marker.iconAtlas);
+	elseif not decorationType or decorationType == DECORATION_TYPES.CHARACTER then
+		marker.Icon:SetAtlas("PartyMember");
 	elseif decorationType == DECORATION_TYPES.HOUSE then
 		marker.Icon:SetAtlas("poi-town");
 	end
+
+	-- Set a custom vertex color on the atlas or reset it to normal if not
+	-- explicitly overridden.
+	if marker.iconColor then
+		marker.Icon:SetVertexColor(marker.iconColor:GetRGBA());
+	else
+		marker.Icon:SetVertexColor(1, 1, 1, 1);
+	end
+
+	-- Change the draw layer if requested.
+	local layer = marker.Icon:GetDrawLayer();
+	marker.Icon:SetDrawLayer(layer, marker.iconSublevel or 0);
 end
 
 ---@param structure table

--- a/totalRP3/modules/register/characters/register_ignore.lua
+++ b/totalRP3/modules/register/characters/register_ignore.lua
@@ -18,6 +18,7 @@
 ----------------------------------------------------------------------------------
 
 local Events = TRP3_API.events;
+local Globals = TRP3_API.globals;
 local showTextInputPopup = TRP3_API.popup.showTextInputPopup;
 local loc = TRP3_API.locale.getText;
 local assert, tostring, time, wipe, strconcat, pairs, tinsert = assert, tostring, time, wipe, strconcat, pairs, tinsert;
@@ -34,16 +35,8 @@ local profiles, characters, blackList, whiteList;
 -- Relation
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-local RELATIONS = {
-	UNFRIENDLY = "UNFRIENDLY",
-	NONE = "NONE",
-	NEUTRAL = "NEUTRAL",
-	BUSINESS = "BUSINESS",
-	FRIEND = "FRIEND",
-	LOVE = "LOVE",
-	FAMILY = "FAMILY"
-}
-TRP3_API.register.relation = RELATIONS;
+local RELATIONS = Globals.RELATIONS;
+TRP3_API.register.relation = Globals.RELATIONS;
 
 local RELATIONS_TEXTURES = {
 	[RELATIONS.UNFRIENDLY] = "Ability_DualWield",

--- a/totalRP3/modules/register/characters/register_main.lua
+++ b/totalRP3/modules/register/characters/register_main.lua
@@ -631,6 +631,9 @@ local function scanMarkerDecorateRelationship(characterID, entry, marker)
 		return;
 	end
 
+	-- Swap out the atlas for this marker.
+	marker.iconAtlas = "PlayerPartyBlip";
+
 	-- Recycle any color instance already present if there is one.
 	local r, g, b = TRP3_API.register.relation.getRelationColors(profileID);
 	marker.iconColor = marker.iconColor or Ellyb.Color(0, 0, 0, 0);
@@ -871,9 +874,15 @@ function TRP3_API.register.init()
 			-- Reset attributes on the marker before decorating.
 			marker.categoryName = nil;
 			marker.categoryPriority = nil;
-			marker.iconColor = nil;
+			marker.iconAtlas = nil;
 			marker.iconSublevel = nil;
 			marker.sortName = characterID;
+
+			-- We'll reset the color rather than nil it out and potentially
+			-- allocate a new one anyway.
+			if marker.iconColor then
+				marker.iconColor:SetRGBA(1, 1, 1, 1);
+			end
 
 			local line;
 			if isUnitIDKnown(characterID) and getUnitIDCurrentProfile(characterID) then

--- a/totalRP3/modules/register/characters/register_main.lua
+++ b/totalRP3/modules/register/characters/register_main.lua
@@ -30,6 +30,7 @@ TRP3_API.register.MENU_LIST_ID = "main_30_register";
 TRP3_API.register.MENU_LIST_ID_TAB = "main_31_";
 
 -- imports
+local Ellyb = TRP3_API.Ellyb;
 local Globals = TRP3_API.globals;
 local Utils = TRP3_API.utils;
 local stEtN = Utils.str.emptyToNil;
@@ -595,6 +596,56 @@ local function cleanupMyProfiles()
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
+-- Scan Marker Decorators
+--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
+
+-- SCAN_MARKER_BLIP_RELATIONSHIP_SUBLEVEL is a texture sublevel applied to the
+-- blip for markers representing characters you have relationship states set
+-- with.
+--
+-- The net result is they'll take priority in the draw order, and get shown
+-- on top of a pile of dots in crowded scenarios.
+local SCAN_MARKER_BLIP_RELATIONSHIP_SUBLEVEL = 4;
+
+--- Decorates a marker with additional information based upon the established
+--  relationship defined in the characters' profile.
+--
+--  @param characterID The ID of the character.
+--  @param entry The entry containing the scan result data.
+--  @param marker The marker blip being decorated.
+local function scanMarkerDecorateRelationship(characterID, entry, marker)
+	-- Skip bad character IDs.
+	if not isUnitIDKnown(characterID) then
+		return;
+	end
+
+	-- Easiest way to get at relationship stuff takes the profile ID.
+	local profileID = getUnitIDProfileID(characterID);
+	if not profileID then
+		return;
+	end
+
+	local relation = TRP3_API.register.relation.getRelation(profileID);
+	if relation == TRP3_API.register.relation.NONE then
+		-- This profile has no relationship status.
+		return;
+	end
+
+	-- Recycle any color instance already present if there is one.
+	local r, g, b = TRP3_API.register.relation.getRelationColors(profileID);
+	marker.iconColor = marker.iconColor or Ellyb.Color(0, 0, 0, 0);
+	marker.iconColor:SetRGBA(r, g, b, 1);
+
+	-- Arbitrary increase in layer means we'll display these icons over the
+	-- defaults.
+	marker.iconSublevel = SCAN_MARKER_BLIP_RELATIONSHIP_SUBLEVEL;
+
+	-- Store the relationship on the marker itself as the category.
+	marker.categoryName = loc("REG_RELATION_" .. relation);
+	marker.categoryPriority = Globals.RELATIONS_ORDER[relation] or -math.huge;
+end
+
+--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- INIT
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
@@ -618,9 +669,6 @@ function TRP3_API.register.init()
 
 	-- Listen to the mouse over event
 	Utils.event.registerHandler("UPDATE_MOUSEOVER_UNIT", onMouseOver);
-
-
-
 
 	registerMenu({
 		id = "main_10_player",
@@ -820,10 +868,21 @@ function TRP3_API.register.init()
 		scanComplete = function(saveStructure)
 		end,
 		scanMarkerDecorator = function(characterID, entry, marker)
+			-- Reset attributes on the marker before decorating.
+			marker.categoryName = nil;
+			marker.categoryPriority = nil;
+			marker.iconColor = nil;
+			marker.iconSublevel = nil;
+			marker.sortName = characterID;
+
 			local line;
 			if isUnitIDKnown(characterID) and getUnitIDCurrentProfile(characterID) then
 				local profile = getUnitIDCurrentProfile(characterID);
 				line = TRP3_API.register.getCompleteName(profile.characteristics, characterID, true);
+
+				-- Sort by the proper name of the character instead.
+				marker.sortName = line;
+
 				if profile.characteristics and profile.characteristics.CH then
 					line = "|cff" .. profile.characteristics.CH .. line;
 				end
@@ -832,6 +891,8 @@ function TRP3_API.register.init()
 				line = 	characterID:gsub("%-.*$", "");
 			end
 			marker.scanLine = line;
+
+			scanMarkerDecorateRelationship(characterID, entry, marker);
 		end,
 		scanDuration = 2.5;
 	});


### PR DESCRIPTION
No actual ticket for this feature, I came up with the idea last night though and so far I'm loving the potential usefulness of it.

![24332464694926e3ea7f46b1f0e35195](https://user-images.githubusercontent.com/287102/36937490-0331a322-1f0c-11e8-9240-5d9310df0c39.jpg)

The current implementation colours blips according to the relationship status of a characters' profile (so hated = red, friend = green, etc.) as well as colouring based upon whether or not that character is on your friends list.

The priority right now is friends > relationships > others. I keep flip-flopping this in my mind, so it could be made into an option I guess.

The blips for players without relationships are unchanged and remain the same colour and texture. Ones that do get changed use the vertex-colourable party member minimap blip and get coded accordingly. In particular, WoW friends get a purple-ish colour and Battle.net friends get the standard BNet whisper colour.

There's a few other changes I want to make - in particular a filtering system. Clicking the scan button would have some additional options like "Show only friends", "Show characters with relationships", and so on.

Finally I want to work a bit on the tooltip display, particularly for large player clusters. I'm thinking if the number of entries is over some arbitrary lower bound, we display the tooltip in a two-column format. If it's over a higher bound, we cut it off and just have a line at the end saying "<x> additional characters in this area.".

I also want to then group the tooltip a bit, so you'd have blips that represent characters with relationships or friends in separate sections at the top.

Thoughts? Opened the PR early in case anyone thinks this is a terrible idea 😄 .