### PR TITLE
Fix alpha of map blips when animations disabled

### DIFF
--- a/totalRP3/modules/map/map_markers.lua
+++ b/totalRP3/modules/map/map_markers.lua
@@ -133,6 +133,8 @@ local function animateMarker(marker, x, y, directAnimation)
 			playAnimation(marker.Bounce);
 		end
 	else
+		-- The default alpha on the widget is zero, so need to change it here.
+		marker:SetAlpha(1);
 		marker:Show();
 	end
 end


### PR DESCRIPTION
Fixes #94.

The XML definition sets alpha to 0 on newly created blips. In the event animations are disabled, this never gets increased to 1, so you're left with invisible blips (albeit with tooltip functionality).