### PR TITLE
Swap to Ellyb.Color.CreateFromRGBAAsBytes

### DIFF
--- a/totalRP3/core/impl/globals.lua
+++ b/totalRP3/core/impl/globals.lua
@@ -87,8 +87,8 @@ TRP3_API.globals = {
 	PSYCHO_MAX_VALUE_V1 = 6,
 	PSYCHO_DEFAULT_VALUE_V2 = 10,
 	PSYCHO_MAX_VALUE_V2 = 20,
-	PSYCHO_DEFAULT_LEFT_COLOR = Ellyb.Color(255, 140, 26):Freeze(),
-	PSYCHO_DEFAULT_RIGHT_COLOR = Ellyb.Color(32, 208, 249):Freeze(),
+	PSYCHO_DEFAULT_LEFT_COLOR = Ellyb.Color.CreateFromRGBAAsBytes(255, 140, 26):Freeze(),
+	PSYCHO_DEFAULT_RIGHT_COLOR = Ellyb.Color.CreateFromRGBAAsBytes(32, 208, 249):Freeze(),
 }
 
 local emptyMeta = {

--- a/totalRP3/modules/register/characters/register_characteristics.lua
+++ b/totalRP3/modules/register/characters/register_characteristics.lua
@@ -1060,11 +1060,11 @@ function setEditDisplay()
 			--        as well as not worry about all the Ellyb.Color -> rgb
 			--        conversion nonsense.
 			frame.CustomLeftColor.onSelection = function(r, g, b)
-				refreshPsychoColor(frame, "LC", r and Ellyb.Color(r, g, b));
+				refreshPsychoColor(frame, "LC", r and Ellyb.Color.CreateFromRGBAAsBytes(r, g, b));
 			end
 
 			frame.CustomRightColor.onSelection = function(r, g, b)
-				refreshPsychoColor(frame, "RC", r and Ellyb.Color(r, g, b));
+				refreshPsychoColor(frame, "RC", r and Ellyb.Color.CreateFromRGBAAsBytes(r, g, b));
 			end
 
 			tinsert(psychoEditCharFrame, frame);


### PR DESCRIPTION
Fixes issues with user-input color values, such as RGB 1/1/1, which would display as white instead of near-black. Tested ingame, verified everything displays and persists fine.

All other call sites pass the saved variables structure itself in, which is the table form, so wouldn't have triggered the bug anyway.

Includes newer version of Ellyb as required.