### PR TITLE
Fix for stopSoundID

### DIFF
--- a/totalRP3/core/impl/utils.lua
+++ b/totalRP3/core/impl/utils.lua
@@ -1004,7 +1004,7 @@ function Utils.music.playSoundID(soundID, channel, source)
 	assert(soundID, "soundID can't be nil.")
 	local willPlay, handlerID = PlaySound(soundID, channel, false);
 	if willPlay then
-		tinsert(soundHandlers, {channel = channel, id = soundID, handlerID = handlerID, source = source, date = date("%H:%M:%S")});
+		tinsert(soundHandlers, {channel = channel, id = tonumber(soundID), handlerID = handlerID, source = source, date = date("%H:%M:%S")});	-- I'm thoroughly confused as to why soundID is a string when playing local sounds, but not when stopping them.
 		if TRP3_SoundsHistoryFrame then
 			TRP3_SoundsHistoryFrame.onSoundPlayed();
 		end
@@ -1017,9 +1017,18 @@ function Utils.music.stopSound(handlerID)
 end
 
 function Utils.music.stopSoundID(soundID, channel, source)
-	for index, handler in pairs(soundHandlers) do
+	local i=1;
+	while i <= #soundHandlers do
+		local handler = soundHandlers[i];
 		if (not soundID or handler.id == soundID) and (not channel or handler.channel == channel) and (not source or handler.source == source) then
-			Utils.music.stopSound(handler.handlerID);
+			if (handler.channel == "Music" and handler.handlerID == 0) then
+				StopMusic();
+			else
+				Utils.music.stopSound(handler.handlerID);
+			end
+			table.remove(soundHandlers, i);
+		else
+			i = i + 1;
 		end
 	end
 end

--- a/totalRP3/core/impl/utils.lua
+++ b/totalRP3/core/impl/utils.lua
@@ -1004,7 +1004,7 @@ function Utils.music.playSoundID(soundID, channel, source)
 	assert(soundID, "soundID can't be nil.")
 	local willPlay, handlerID = PlaySound(soundID, channel, false);
 	if willPlay then
-		tinsert(soundHandlers, {channel = channel, id = soundID, handlerID = handlerID, source = source, date = date("%H:%M:%S")});	
+		tinsert(soundHandlers, {channel = channel, id = soundID, handlerID = handlerID, source = source, date = date("%H:%M:%S"), stopped = false});	
 		if TRP3_SoundsHistoryFrame then
 			TRP3_SoundsHistoryFrame.onSoundPlayed();
 		end
@@ -1018,12 +1018,13 @@ end
 
 function Utils.music.stopSoundID(soundID, channel, source)
 	for index, handler in pairs(soundHandlers) do
-		if (not soundID or soundID == "0" or handler.id == soundID) and (not channel or handler.channel == channel) and (not source or handler.source == source) then
+		if (not handler.stopped) and (not soundID or soundID == "0" or handler.id == soundID) and (not channel or handler.channel == channel) and (not source or handler.source == source) then
 			if (handler.channel == "Music" and handler.handlerID == 0) then
 				StopMusic();
 			else
 				Utils.music.stopSound(handler.handlerID);
 			end
+			handler.stopped = true;
 		end
 	end
 end
@@ -1046,7 +1047,7 @@ function Utils.music.playMusic(music, source)
 	else
 		Log.log("Playing music: " .. music);
 		PlayMusic("Sound\\Music\\" .. music .. ".mp3");
-		tinsert(soundHandlers, {channel = "Music", id = music, handlerID = 0, source = source or Globals.player_id, date = date("%H:%M:%S")});
+		tinsert(soundHandlers, {channel = "Music", id = music, handlerID = 0, source = source or Globals.player_id, date = date("%H:%M:%S"), stopped = false});
 		if TRP3_SoundsHistoryFrame then
 			TRP3_SoundsHistoryFrame.onSoundPlayed();
 		end

--- a/totalRP3/core/impl/utils.lua
+++ b/totalRP3/core/impl/utils.lua
@@ -1004,7 +1004,7 @@ function Utils.music.playSoundID(soundID, channel, source)
 	assert(soundID, "soundID can't be nil.")
 	local willPlay, handlerID = PlaySound(soundID, channel, false);
 	if willPlay then
-		tinsert(soundHandlers, {channel = channel, id = tonumber(soundID), handlerID = handlerID, source = source, date = date("%H:%M:%S")});	-- I'm thoroughly confused as to why soundID is a string when playing local sounds, but not when stopping them.
+		tinsert(soundHandlers, {channel = channel, id = soundID, handlerID = handlerID, source = source, date = date("%H:%M:%S")});	
 		if TRP3_SoundsHistoryFrame then
 			TRP3_SoundsHistoryFrame.onSoundPlayed();
 		end
@@ -1017,18 +1017,13 @@ function Utils.music.stopSound(handlerID)
 end
 
 function Utils.music.stopSoundID(soundID, channel, source)
-	local i=1;
-	while i <= #soundHandlers do
-		local handler = soundHandlers[i];
-		if (not soundID or handler.id == soundID) and (not channel or handler.channel == channel) and (not source or handler.source == source) then
+	for index, handler in pairs(soundHandlers) do
+		if (not soundID or soundID == "0" or handler.id == soundID) and (not channel or handler.channel == channel) and (not source or handler.source == source) then
 			if (handler.channel == "Music" and handler.handlerID == 0) then
 				StopMusic();
 			else
 				Utils.music.stopSound(handler.handlerID);
 			end
-			table.remove(soundHandlers, i);
-		else
-			i = i + 1;
 		end
 	end
 end


### PR DESCRIPTION
Maybe the function should be renamed, but here's what's been done : 
- soundID as "0" works the same way as nil, as I seemingly can't broadcast nil.
- If the handle is on the Music channel, checking the handlerID to make sure we're using the right function for the job.
- The "stopped" boolean is there to handle an edge case where a player starts a music, replaced by another player's music. The first player would be able to stop the second player's music with his "Stop local music".