### PR TITLE
Closing NPC speech frame when pressing Esc

### DIFF
--- a/totalRP3/modules/dashboard/dashboard.xml
+++ b/totalRP3/modules/dashboard/dashboard.xml
@@ -140,6 +140,11 @@
 		<Anchors>
 			<Anchor point="CENTER"/>
 		</Anchors>
+		<Scripts>
+			<OnLoad>
+				tinsert(UISpecialFrames, self:GetName());
+			</OnLoad>
+		</Scripts>
 		<Layers>
 			<Layer level="OVERLAY">
 				<FontString parentKey="title" inherits="GameFontNormalLarge" justifyH="CENTER" justifyV="MIDDLE" setAllPoints="true">


### PR DESCRIPTION
Same fix as I did on Extended for the inventory & sounds history frames, adding the frame to UISpecialFrames.