### PR TITLE
 Adding a nil check to the latest flyway patch 

### DIFF
--- a/totalRP3/modules/flyway/flyway_patches.lua
+++ b/totalRP3/modules/flyway/flyway_patches.lua
@@ -86,6 +86,7 @@ end
 
 -- Patches potentially badly created profiles from chat links
 TRP3_API.flyway.patches["7"] = function()
+	if not TRP3_Register then return end
 	for _, profile in pairs(TRP3_Register.profiles) do
 		if not profile.link then
 			profile.link = {};

--- a/totalRP3/modules/flyway/flyway_patches.lua
+++ b/totalRP3/modules/flyway/flyway_patches.lua
@@ -86,7 +86,7 @@ end
 
 -- Patches potentially badly created profiles from chat links
 TRP3_API.flyway.patches["7"] = function()
-	if not TRP3_Register then return end
+	if not (TRP3_Register and TRP3_Register.profiles) then return end
 	for _, profile in pairs(TRP3_Register.profiles) do
 		if not profile.link then
 			profile.link = {};


### PR DESCRIPTION
The latest flyway patch wasn't testing that there was a register or profiles in it before trying to apply the patch. Seems like it could break it, so I added the test.