### PR TITLE
Fixed TRP3_ROLL event

### DIFF
--- a/totalRP3/core/impl/slash.lua
+++ b/totalRP3/core/impl/slash.lua
@@ -157,7 +157,6 @@ function TRP3_API.slash.rollDices(...)
 	end
 	Utils.message.displayMessage(totalMessage, 3);
 	TRP3_API.ui.misc.playSoundKit(36629, "SFX");
-	Utils.event.fireEvent("TRP3_ROLL", strjoin(" ", unpack(args)), total);
 
 	return total, i;
 end

--- a/totalRP3/core/impl/slash.lua
+++ b/totalRP3/core/impl/slash.lua
@@ -157,6 +157,7 @@ function TRP3_API.slash.rollDices(...)
 	end
 	Utils.message.displayMessage(totalMessage, 3);
 	TRP3_API.ui.misc.playSoundKit(36629, "SFX");
+	Events.fireEvent("TRP3_ROLL", strjoin(" ", unpack(args)), total);
 
 	return total, i;
 end


### PR DESCRIPTION
While checking for any remaining Utils.event.fireEvent of custom events that might be left in the code, I stumbled upon this one which isn't used anywhere in the code, and doesn't actually seem to serve a useful purpose (as it's sending an event with the dice rolled, but not the result itself ?).

We can fix it on the offchance someone randomly decided to listen to it in an Extended campaign, if you'd prefer.