### PR TITLE
Map changes for 8.0

### DIFF
--- a/totalRP3/modules/map/map.xml
+++ b/totalRP3/modules/map/map.xml
@@ -25,7 +25,7 @@
 		</Frames>
 		<Scripts>
 			<OnEnter>
-					WorldMapPOIFrame.allowBlobTooltip = false;
+					--WorldMapPOIFrame.allowBlobTooltip = false;
 					WorldMapTooltip:Hide();
 					WorldMapTooltip:SetOwner(self, "ANCHOR_RIGHT",0,0);
 					WorldMapTooltip:AddLine(self.title, 1, 1, 1,true);

--- a/totalRP3/modules/map/map_markers.lua
+++ b/totalRP3/modules/map/map_markers.lua
@@ -49,12 +49,9 @@ local TRP3_ScanLoaderFrame = TRP3_ScanLoaderFrame;
 -- Utils
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-local GetPlayerMapPosition = GetPlayerMapPosition;
-local GetCurrentMapAreaID = GetCurrentMapAreaID;
-
 function TRP3_API.map.getCurrentCoordinates()
-	local mapID = GetCurrentMapAreaID();
-	local x, y = GetPlayerMapPosition("player");
+	local mapID = C_Map.GetBestMapForUnit("player");
+	local x, y = C_Map.GetPlayerMapPosition(mapID, "player"):GetXY();
 	return mapID, x, y;
 end
 
@@ -306,7 +303,7 @@ function launchScan(scanID)
 		wipe(structure.saveStructure);
 		structure.scan(structure.saveStructure);
 		if structure.scanDuration then
-			local mapID = GetCurrentMapAreaID();
+			local mapID = WorldMapFrame:GetMapID();
 			currentMapID = mapID;
 			TRP3_WorldMapButton:Disable();
 			setupIconButton(TRP3_WorldMapButton, "ability_mage_timewarp");
@@ -326,7 +323,7 @@ function launchScan(scanID)
 			after(structure.scanDuration, function()
 				TRP3_WorldMapButton:Enable();
 				setupIconButton(TRP3_WorldMapButton, "icon_treasuremap");
-				if mapID == GetCurrentMapAreaID() then
+				if mapID == WorldMapFrame:GetMapID() then
 					if structure.scanComplete then
 						structure.scanComplete(structure.saveStructure);
 					end
@@ -373,7 +370,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 	setupIconButton(TRP3_WorldMapButton, "icon_treasuremap");
 	TRP3_WorldMapButton.title = loc.MAP_BUTTON_TITLE;
 	TRP3_WorldMapButton.subtitle = YELLOW(loc.MAP_BUTTON_SUBTITLE);
-	TRP3_WorldMapButton:SetScript("OnClick", onButtonClicked);
+	--TRP3_WorldMapButton:SetScript("OnClick", onButtonClicked);	-- TODO : Update scans with the 8.0 changes. For now, disabling button and changing the message.
 	TRP3_ScanLoaderFrameScanning:SetText(loc.MAP_BUTTON_SCANNING);
 
 
@@ -470,8 +467,9 @@ end);
 -- When we get BROADCAST_CHANNEL_READY it's time to enable the button use the
 -- standard tooltip description.
 TRP3_API.events.listenToEvent(TRP3_API.events.BROADCAST_CHANNEL_READY, function()
-	TRP3_WorldMapButton:SetEnabled(true);
-	TRP3_WorldMapButton.subtitle = YELLOW(loc.MAP_BUTTON_SUBTITLE);
+	-- TODO : Update scans with the 8.0 changes. For now, disabling button and changing the message.
+	TRP3_WorldMapButton:SetEnabled(false);
+	TRP3_WorldMapButton.subtitle = TRP3_API.Ellyb.ColorManager.RED(loc.MAP_BUTTON_SUBTITLE_80_DISABLED);
 
-	TRP3_WorldMapButtonIcon:SetDesaturated(false);
+	TRP3_WorldMapButtonIcon:SetDesaturated(true);
 end);

--- a/totalRP3/modules/map/map_markers.lua
+++ b/totalRP3/modules/map/map_markers.lua
@@ -51,8 +51,11 @@ local TRP3_ScanLoaderFrame = TRP3_ScanLoaderFrame;
 
 function TRP3_API.map.getCurrentCoordinates()
 	local mapID = C_Map.GetBestMapForUnit("player");
-	local x, y = C_Map.GetPlayerMapPosition(mapID, "player"):GetXY();
-	return mapID, x, y;
+	local mapVector = C_Map.GetPlayerMapPosition(mapID, "player");
+	if mapVector then
+		local x, y = mapVector:GetXY();
+		return mapID, x, y;
+	end
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*

--- a/totalRP3/modules/register/characters/register_characteristics.lua
+++ b/totalRP3/modules/register/characters/register_characteristics.lua
@@ -1404,9 +1404,14 @@ function TRP3_API.register.inits.characteristicsInit()
 	TRP3_RegisterCharact_Edit_ResidenceButton:RegisterForClicks("LeftButtonUp", "RightButtonUp");
 	TRP3_RegisterCharact_Edit_ResidenceButton:SetScript("OnClick", function(self, button)
 		if button == "LeftButton" then
-			draftData.RC = {TRP3_API.map.getCurrentCoordinates()};
-			tinsert(draftData.RC, Utils.str.buildZoneText());
-			TRP3_RegisterCharact_Edit_ResidenceField:SetText(buildZoneText());
+			if TRP3_API.map.getCurrentCoordinates() then
+				draftData.RC = {TRP3_API.map.getCurrentCoordinates()};
+				tinsert(draftData.RC, Utils.str.buildZoneText());
+				TRP3_RegisterCharact_Edit_ResidenceField:SetText(buildZoneText());
+			else
+				draftData.RC = nil;
+				TRP3_RegisterCharact_Edit_ResidenceField:SetText(buildZoneText());
+			end
 		else
 			draftData.RC = nil;
 			TRP3_RegisterCharact_Edit_ResidenceField:SetText("");

--- a/totalRP3/modules/register/characters/register_main.lua
+++ b/totalRP3/modules/register/characters/register_main.lua
@@ -864,9 +864,7 @@ function TRP3_API.register.init()
 		scanResponder = function(sender, zoneID)
 			if locationEnabled() and playersCanSeeEachOthers(sender) then
 				local mapID, x, y = TRP3_API.map.getCurrentCoordinates("player");
-				x = x or 0;
-				y = y or 0;
-				if tonumber(mapID) == tonumber(zoneID) and not (x == 0 and y == 0) then
+				if mapID and x and y and tonumber(mapID) == tonumber(zoneID) then
 					broadcast.sendP2PMessage(sender, CHARACTER_SCAN_COMMAND, x, y, zoneID, Globals.addon_name_short);
 				end
 			end;

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1220,6 +1220,7 @@ Would you like to reload the interface now?]],
 	TT_ELVUI_SKIN = "ElvUI skin",
 	TT_ELVUI_SKIN_ENABLE_TOOLTIPS = "Skin tooltips",
 	TT_ELVUI_SKIN_ENABLE_TARGET_FRAME = "Skin target frame",
+	MAP_BUTTON_SUBTITLE_80_DISABLED = "Scans temporarily unavailable due to 8.0 changes",
 };
 
 -- Use Ellyb to generate the Localization system


### PR DESCRIPTION
Changes I've made for 8.0 : 

- From what I understand, GetCurrentMapAreaID meant either the map where the player is, or the map opened at the moment. I replaced the usages accordingly.
- GetPlayerMapPosition is in C_Map and requires a mapID.
- I will try to take a look into Map data providers later. In case I can't figure it out in time, the scan button on the map has been disabled with an appropriate error message.