### PR TITLE
CheckBox inheritance + minor settings dependency fix

### DIFF
--- a/totalRP3/core/ui/widgets.xml
+++ b/totalRP3/core/ui/widgets.xml
@@ -350,7 +350,7 @@
 	</EditBox>
 
 	<!-- Checkbox with small label and TT compatible -->
-	<CheckButton name="TRP3_CheckBox" inherits="OptionsCheckButtonTemplate" virtual="true" checked="false">
+	<CheckButton name="TRP3_CheckBox" inherits="InterfaceOptionsCheckButtonTemplate" virtual="true" checked="false">
 		<Scripts>
 			<OnLoad>
 				self.Text = _G[self:GetName() .. "Text"];

--- a/totalRP3/modules/register/main/register_cursor.lua
+++ b/totalRP3/modules/register/main/register_cursor.lua
@@ -149,6 +149,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 		title = loc.CO_CURSOR_DISABLE_OOC,
 		help = loc.CO_CURSOR_DISABLE_OOC_TT,
 		configKey = CONFIG_RIGHT_CLICK_DISABLE_OOC,
+		dependentOnOptions = { CONFIG_RIGHT_CLICK_OPEN_PROFILE },
 	});
 
 	-- Modifier key dropdown option


### PR DESCRIPTION
Following a short exchange on the Lounge regarding my checkbox issue, it seems the template TRP inherited from for the TRP3_CheckBox isn't the right one anymore. Since we're not always attaching an OnClick script to the checkboxes, it seems like InterfaceOptionsCheckButtonTemplate is the template to use.

As far as I've seen from testing it, nothing changed in the behaviour of the existing checkboxes, and I'm not seeing a Lua error when clicking on checkboxes without a script anymore.

Small additional fix, the checkbox to disable cursor modifications when OOC should be disabled when the modification itself isn't enabled (just like the modifier dropdown).