### PR TITLE
Fixed some alignment issues on the target frame

### DIFF
--- a/totalRP3/modules/flyway/flyway_patches.lua
+++ b/totalRP3/modules/flyway/flyway_patches.lua
@@ -103,3 +103,10 @@ TRP3_API.flyway.patches["8"] = function()
 		end
 	end
 end
+
+-- Reset glance bar coordinates
+TRP3_API.flyway.patches["9"] = function()
+	if TRP3_API.register.resetGlanceBar then
+		TRP3_API.register.resetGlanceBar();
+	end
+end

--- a/totalRP3/modules/register/main/register_glance.lua
+++ b/totalRP3/modules/register/main/register_glance.lua
@@ -731,17 +731,17 @@ local function onStart()
 		local parentScale = UIParent:GetEffectiveScale();
 		ui_GlanceBar:SetParent(parentFrame);
 		ui_GlanceBar:ClearAllPoints();
-		ui_GlanceBar:SetPoint("BOTTOMLEFT", parentFrame, "BOTTOMLEFT", getConfigValue(CONFIG_GLANCE_ANCHOR_X) / parentScale, getConfigValue(CONFIG_GLANCE_ANCHOR_Y) / parentScale);
+		ui_GlanceBar:SetPoint("BOTTOM", parentFrame, "BOTTOM", getConfigValue(CONFIG_GLANCE_ANCHOR_X) / parentScale, getConfigValue(CONFIG_GLANCE_ANCHOR_Y) / parentScale);
 	end
 
 	local function resetPosition()
 		setConfigValue(CONFIG_GLANCE_PARENT, "TRP3_TargetFrame");
-		setConfigValue(CONFIG_GLANCE_ANCHOR_X, 24);
+		setConfigValue(CONFIG_GLANCE_ANCHOR_X, 0);
 		setConfigValue(CONFIG_GLANCE_ANCHOR_Y, -14);
 		replaceBar();
 	end
 
-	-- Function called when the minimap icon is dragged
+	-- Function called when the glance bar is dragged
 	local function glanceBar_DraggingFrame_OnUpdate(self)
 		if not getConfigValue(CONFIG_GLANCE_LOCK) and self.isDraging then
 			local parentFrame = getParentFrame();
@@ -761,7 +761,7 @@ local function onStart()
 	end
 
 	registerConfigKey(CONFIG_GLANCE_PARENT, "TRP3_TargetFrame");
-	registerConfigKey(CONFIG_GLANCE_ANCHOR_X, 24);
+	registerConfigKey(CONFIG_GLANCE_ANCHOR_X, 0);
 	registerConfigKey(CONFIG_GLANCE_ANCHOR_Y, -14);
 	registerConfigKey(CONFIG_GLANCE_LOCK, true);
 	registerConfigKey(CONFIG_GLANCE_TT_ANCHOR, "LEFT");
@@ -772,7 +772,7 @@ local function onStart()
 
 	function TRP3_API.register.resetGlanceBar()
 		setConfigValue(CONFIG_GLANCE_PARENT, "TRP3_TargetFrame");
-		setConfigValue(CONFIG_GLANCE_ANCHOR_X, 24);
+		setConfigValue(CONFIG_GLANCE_ANCHOR_X, 0);
 		setConfigValue(CONFIG_GLANCE_ANCHOR_Y, -14);
 	end
 
@@ -820,7 +820,7 @@ local function onStart()
 				help = loc.CO_GLANCE_PRESET_TRP3_HELP,
 				callback = function()
 					setConfigValue(CONFIG_GLANCE_PARENT, "TRP3_TargetFrame");
-					setConfigValue(CONFIG_GLANCE_ANCHOR_X, 24);
+					setConfigValue(CONFIG_GLANCE_ANCHOR_X, 0);
 					setConfigValue(CONFIG_GLANCE_ANCHOR_Y, -14);
 					replaceBar();
 				end,

--- a/totalRP3/modules/targetframe/target_frame.lua
+++ b/totalRP3/modules/targetframe/target_frame.lua
@@ -144,7 +144,16 @@ local function onStart()
 			x = x + buttonSize + 2;
 		end
 
+		local oldWidth = ui_TargetFrame:GetWidth();
 		ui_TargetFrame:SetWidth(math.max(30 + index * buttonSize, 200));
+		-- Updating anchors so the toolbar expands from the center
+		local anchor, _, _, tfX, tfY = ui_TargetFrame:GetPoint();
+		if anchor == "LEFT" then
+			tfX = tfX - (ui_TargetFrame:GetWidth() - oldWidth) / 2;
+		elseif anchor == "RIGHT" then
+			tfX = tfX + (ui_TargetFrame:GetWidth() - oldWidth) / 2;
+		end
+		ui_TargetFrame:SetPoint(anchor, tfX, tfY);
 		ui_TargetFrame:SetHeight(buttonSize + 23);
 	end
 
@@ -275,7 +284,8 @@ local function onStart()
 		setConfigValue(CONFIG_TARGET_POS_Y, y);
 	end);
 
-	ui_TargetFrame.caption:SetPoint("TOPLEFT", 16, 15);
+	ui_TargetFrame.caption:ClearAllPoints();
+	ui_TargetFrame.caption:SetPoint("TOP", 0, 15);
 	ui_TargetFrame.caption:EnableMouse(true);
 	ui_TargetFrame.caption:RegisterForDrag("LeftButton");
 	ui_TargetFrame.caption:SetScript("OnDragStart", function(self)


### PR DESCRIPTION
- Target frame caption + glance bar now have their position centered relative to the target frame. Unfortunately, to avoid weird positioning after the update, the best course of action was to reset the glance bar position in a flyway patch. (I could technically do math to avoid this, but the glance bar wasn't perfectly centered to begin with as far as I've seen...)

- When too many buttons on the target frame require to expand it, it will now always expand from the center.
**Technical shizzle-whizzle :** when moving the target frame around, it chooses the nearest point of the UIParent as the reference anchor and the same point on the target frame to save the relative position (for instance, on the left of the screen, it'll position the "LEFT" point of the target frame relative to the "LEFT" point of UIParent).
Previously, expanding would only change the width, which means if the target frame was left, it would expand right, and vice-versa. Top, bottom & center would expand from the center. Based on this, after changing the width, I offset the position of the target frame if it is left or right to compensate.
Yes maybe it would have been smarter to change the target frame so it would always use the "CENTER" point as the anchor. But I honestly had no clue how to do it so I went with the math.

- I saw that copy-paste job.