### PR TITLE
Added event for opening a user's profile.

### DIFF
--- a/totalRP3/core/impl/events.lua
+++ b/totalRP3/core/impl/events.lua
@@ -75,21 +75,6 @@ local Events = {
 	-- Called when as "About" page is shown.
 	-- This is used by the tooltip and the target bar to be refreshed
 	REGISTER_ABOUT_READ = "REGISTER_ABOUT_READ",
-
-	-- Called when the user opens a profile in the viewer.
-	-- Arg1 : Profile ID - may be nil when viewing the player's profile.
-	-- Arg2 : Context. This comes in two formats:
-	--         Player's profile format: (triggered when opening from the Character menu)
-	--           source   = "player"
-	--           isPlayer = true
-	--           profile  = player's profile data
-	--         Directory profile format: (triggered when opening someone else's profile)
-	--           source            = "directory".
-	--           profile,profileID = Profile data and ID.
-	--           openingWithUnitID = true if opening the page with a fresh unitID (name).
-	--           unitID            = unitID (name) used to open the page; may be nil or 
-	--                               the previously set value if openingWithUnitID=false.
-	REGISTER_PROFILE_OPENED = "REGISTER_PROFILE_OPENED",
 	
 	-- Called when a notifications is created/read/removed
 	NOTIFICATION_CHANGED = "NOTIFICATION_CHANGED",

--- a/totalRP3/core/impl/events.lua
+++ b/totalRP3/core/impl/events.lua
@@ -74,7 +74,7 @@ local Events = {
 	-- Called when the user opens someone's profile.
 	-- Arg1 : Profile ID
 	-- Arg2 : Unit ID (only given when opening from a unit ID, and not if opening from the directory or similar).
-	REGISTER_PROFILE_READ = "REGISTER_PROFILE_READ",
+	REGISTER_PROFILE_OPENED = "REGISTER_PROFILE_OPENED",
 	
 	-- Called when a notifications is created/read/removed
 	NOTIFICATION_CHANGED = "NOTIFICATION_CHANGED",

--- a/totalRP3/core/impl/events.lua
+++ b/totalRP3/core/impl/events.lua
@@ -71,6 +71,11 @@ local Events = {
 	-- This is used by the tooltip and the target bar to be refreshed
 	REGISTER_ABOUT_READ = "REGISTER_ABOUT_READ",
 
+	-- Called when the user opens someone's profile.
+	-- Arg1 : Profile ID
+	-- Arg2 : Unit ID (only given when opening from a unit ID, and not if opening from the directory or similar).
+	REGISTER_PROFILE_READ = "REGISTER_PROFILE_READ",
+	
 	-- Called when a notifications is created/read/removed
 	NOTIFICATION_CHANGED = "NOTIFICATION_CHANGED",
 	

--- a/totalRP3/core/impl/events.lua
+++ b/totalRP3/core/impl/events.lua
@@ -47,6 +47,11 @@ local Events = {
 	NAVIGATION_TUTORIAL_REFRESH = "NAVIGATION_TUTORIAL_REFRESH",
 	NAVIGATION_RESIZED = "NAVIGATION_RESIZED",
 	
+	-- Called when the user changes the page in the main frame. (setPage)
+	-- Arg1 : Page ID
+	-- Arg2 : Page context
+	PAGE_OPENED = "PAGE_OPENED",
+	
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	-- Data changed
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -71,9 +76,19 @@ local Events = {
 	-- This is used by the tooltip and the target bar to be refreshed
 	REGISTER_ABOUT_READ = "REGISTER_ABOUT_READ",
 
-	-- Called when the user opens someone's profile.
-	-- Arg1 : Profile ID
-	-- Arg2 : Unit ID (only given when opening from a unit ID, and not if opening from the directory or similar).
+	-- Called when the user opens a profile in the viewer.
+	-- Arg1 : Profile ID - may be nil when viewing the player's profile.
+	-- Arg2 : Context. This comes in two formats:
+	--         Player's profile format: (triggered when opening from the Character menu)
+	--           source   = "player"
+	--           isPlayer = true
+	--           profile  = player's profile data
+	--         Directory profile format: (triggered when opening someone else's profile)
+	--           source            = "directory".
+	--           profile,profileID = Profile data and ID.
+	--           openingWithUnitID = true if opening the page with a fresh unitID (name).
+	--           unitID            = unitID (name) used to open the page; may be nil or 
+	--                               the previously set value if openingWithUnitID=false.
 	REGISTER_PROFILE_OPENED = "REGISTER_PROFILE_OPENED",
 	
 	-- Called when a notifications is created/read/removed

--- a/totalRP3/core/impl/main_structure.lua
+++ b/totalRP3/core/impl/main_structure.lua
@@ -272,6 +272,8 @@ local function setPage(pageId, context)
 	
 	TRP3_API.events.fireEvent(TRP3_API.events.NAVIGATION_TUTORIAL_REFRESH, pageId);
 	playUISound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
+	
+	TRP3_API.Events.triggerEvent(TRP3_API.Events.PAGE_OPENED, pageId, context)
 end
 TRP3_API.navigation.page.setPage = setPage;
 

--- a/totalRP3/modules/register/characters/register_main.lua
+++ b/totalRP3/modules/register/characters/register_main.lua
@@ -904,9 +904,3 @@ function TRP3_API.register.init()
 		scanDuration = 2.5;
 	});
 end
-
-Events.registerCallback( Events.PAGE_OPENED, function( pageId, context )
-	if pageId == "player_main" then
-		Events.triggerEvent(Events.REGISTER_PROFILE_OPENED, context )
-	end
-end)

--- a/totalRP3/modules/register/characters/register_main.lua
+++ b/totalRP3/modules/register/characters/register_main.lua
@@ -703,6 +703,7 @@ function TRP3_API.register.init()
 		text = get("player/characteristics/FN") or Globals.player,
 		onSelected = function()
 			setPage("player_main", {
+				source = "player",
 				profile = get("player"),
 				isPlayer = true,
 			});
@@ -903,3 +904,9 @@ function TRP3_API.register.init()
 		scanDuration = 2.5;
 	});
 end
+
+Events.registerCallback( Events.PAGE_OPENED, function( pageId, context )
+	if pageId == "player_main" then
+		Events.triggerEvent(Events.REGISTER_PROFILE_OPENED, context )
+	end
+end)

--- a/totalRP3/modules/register/main/register_list.lua
+++ b/totalRP3/modules/register/main/register_list.lua
@@ -99,6 +99,8 @@ local function openPage(profileID, unitID)
 			TRP3_MatureFilterPopup.menuID = currentlyOpenedProfilePrefix .. profileID;
 		end
 	end
+	
+	Events.triggerEvent(Events.REGISTER_PROFILE_READ, profileID, unitID)
 end
 TRP3_API.register.openPageByProfileID = openPage;
 

--- a/totalRP3/modules/register/main/register_list.lua
+++ b/totalRP3/modules/register/main/register_list.lua
@@ -73,34 +73,50 @@ local REGISTER_PAGE = TRP3_API.register.MENU_LIST_ID;
 
 local function openPage(profileID, unitID)
 	local profile = getProfile(profileID);
-	if isMenuRegistered(currentlyOpenedProfilePrefix .. profileID) then
+	local menuID = currentlyOpenedProfilePrefix .. profileID
+	if isMenuRegistered(menuID) then
+		local menuItem = TRP3_API.navigation.menu.getMenuItem(menuID)
+		if unitID then
+			menuItem.pageContext.unitID            = unitID
+			menuItem.pageContext.openingWithUnitID = true
+		end
 		-- If the character already has his "tab", simply open it
-		selectMenu(currentlyOpenedProfilePrefix .. profileID);
+		selectMenu(menuID);
+		TRP3_API.navigation.page.getCurrentContext().openingWithUnitID = false
 	else
 		-- Else, create a new menu entry and open it.
 		local tabText = UNKNOWN;
 		if profile.characteristics and profile.characteristics.FN then
 			tabText = profile.characteristics.FN;
 		end
+		local pageContext = {
+			-- source isn't used, but useful in to know where you're getting the
+			-- REGISTER_PROFILE_OPENED event from.
+			source            = "directory",
+			profile           = profile,
+			profileID         = profileID,
+			unitID            = unitID,
+			openingWithUnitID = unitID ~= nil
+		}
 		registerMenu({
-			id = currentlyOpenedProfilePrefix .. profileID,
+			id = menuID,
 			text = tabText,
-			onSelected = function() setPage("player_main", {profile = profile, profileID = profileID}) end,
+			onSelected = function() setPage("player_main", pageContext ) end,
 			isChildOf = REGISTER_PAGE,
 			closeable = true,
 			icon = "Interface\\ICONS\\pet_type_humanoid",
+			pageContext = pageContext,
 		});
-		selectMenu(currentlyOpenedProfilePrefix .. profileID);
+		selectMenu(menuID);
+		TRP3_API.navigation.page.getCurrentContext().openingWithUnitID = false
 
 		if (unitID and unitIDIsFilteredForMatureContent(unitID)) or (profileID and profileIDISFilteredForMatureContent(profileID)) then
 			TRP3_API.popup.showPopup("mature_filtered");
 			TRP3_MatureFilterPopup.profileID = profileID;
 			TRP3_MatureFilterPopup.unitID = unitID;
-			TRP3_MatureFilterPopup.menuID = currentlyOpenedProfilePrefix .. profileID;
+			TRP3_MatureFilterPopup.menuID = menuID;
 		end
 	end
-	
-	Events.triggerEvent(Events.REGISTER_PROFILE_OPENED, profileID, unitID)
 end
 TRP3_API.register.openPageByProfileID = openPage;
 

--- a/totalRP3/modules/register/main/register_list.lua
+++ b/totalRP3/modules/register/main/register_list.lua
@@ -100,7 +100,7 @@ local function openPage(profileID, unitID)
 		end
 	end
 	
-	Events.triggerEvent(Events.REGISTER_PROFILE_READ, profileID, unitID)
+	Events.triggerEvent(Events.REGISTER_PROFILE_OPENED, profileID, unitID)
 end
 TRP3_API.register.openPageByProfileID = openPage;
 


### PR DESCRIPTION
Added two events, `PAGE_OPENED(pageId, pageContext)` and `REGISTER_PROFILE_OPENED(pageContext)`. The latter is a mere convenience that filters only listens for the page "player_main" from `PAGE_OPENED`.

Added a few fields to the register page context to preserve the unit ID when opening profiles with methods that support it.

I was going to have `REGISTER_PROFILE_OPENED` get its arguments from the context values, but passing the whole context structure seems more future compatible. The `source` field I added should also help with future compatibility.
