### PR TITLE
Removing profile compression

### DIFF
--- a/totalRP3/modules/register/characters/register_about.lua
+++ b/totalRP3/modules/register/characters/register_about.lua
@@ -475,11 +475,7 @@ local function compressData()
 end
 
 function TRP3_API.register.player.getAboutExchangeData()
-	if currentCompressed ~= nil then
-		return currentCompressed;
-	else
-		return getOptimizedData();
-	end
+	return getOptimizedData();
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*

--- a/totalRP3/modules/register/characters/register_about.lua
+++ b/totalRP3/modules/register/characters/register_about.lua
@@ -441,8 +441,6 @@ end
 -- COMPRESSION
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-local currentCompressed;
-
 local function getOptimizedData()
 	local dataTab = get("player/about");
 	-- Optimize : only send the selected template
@@ -460,18 +458,6 @@ local function getOptimizedData()
 		dataToSend.T3 = nil;
 	end
 	return dataToSend;
-end
-
-local function compressData()
-	local dataTab = getOptimizedData();
-	local serial = Utils.serial.serialize(dataTab);
-	local compressed = Utils.serial.safeEncodeCompressMessage(serial);
-
-	if compressed and compressed:len() < serial:len() then
-		currentCompressed = compressed;
-	else
-		currentCompressed = nil;
-	end
 end
 
 function TRP3_API.register.player.getAboutExchangeData()
@@ -556,7 +542,6 @@ local function save()
 	assert(type(dataTab.v) == "number", "Error: No version in draftData or not a number.");
 	dataTab.v = Utils.math.incrementNumber(dataTab.v, 2);
 
-	compressData();
 	Events.fireEvent(Events.REGISTER_DATA_UPDATED, Globals.player_id, getCurrentContext().profileID, "about");
 end
 
@@ -882,9 +867,6 @@ function TRP3_API.register.inits.aboutInit()
 	TRP3_RegisterAbout_AboutPanel_MusicPlayer_Stop:SetScript("OnClick", function()
 		Utils.music.stopMusic();
 	end);
-
-	Events.listenToEvent(Events.REGISTER_PROFILES_LOADED, compressData); -- On profile change, compress the new data
-	compressData();
 
 	Events.listenToEvent(Events.REGISTER_DATA_UPDATED, function(unitID, profileID, dataType)
 		if dataType == "about" and unitID and unitID ~= Globals.player_id then

--- a/totalRP3/modules/register/characters/register_characteristics.lua
+++ b/totalRP3/modules/register/characters/register_characteristics.lua
@@ -123,11 +123,7 @@ local function compressData()
 end
 
 function TRP3_API.register.player.getCharacteristicsExchangeData()
-	if currentCompressed ~= nil then
-		return currentCompressed;
-	else
-		return get("player/characteristics");
-	end
+	return get("player/characteristics");
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*

--- a/totalRP3/modules/register/characters/register_characteristics.lua
+++ b/totalRP3/modules/register/characters/register_characteristics.lua
@@ -108,20 +108,6 @@ TRP3_API.register.ui.sanitizeCharacteristics = sanitizeCharacteristics;
 -- COMPRESSION
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-local currentCompressed;
-
-local function compressData()
-	local dataTab = get("player/characteristics");
-	local serial = Utils.serial.serialize(dataTab);
-	local compressed = Utils.serial.safeEncodeCompressMessage(serial);
-
-	if compressed and compressed:len() < serial:len() then
-		currentCompressed = compressed;
-	else
-		currentCompressed = nil;
-	end
-end
-
 function TRP3_API.register.player.getCharacteristicsExchangeData()
 	return get("player/characteristics");
 end
@@ -1170,7 +1156,6 @@ local function saveCharacteristics()
 	assert(type(dataTab.v) == "number", "Error: No version in draftData or not a number.");
 	dataTab.v = Utils.math.incrementNumber(dataTab.v, 2);
 
-	compressData();
 	Events.fireEvent(Events.REGISTER_DATA_UPDATED, Globals.player_id, getCurrentContext().profileID, "characteristics");
 end
 
@@ -1492,8 +1477,6 @@ function TRP3_API.register.inits.characteristicsInit()
 	TRP3_RegisterCharact_Edit_ResidenceFieldText:SetText(loc.REG_PLAYER_RESIDENCE);
 	TRP3_RegisterCharact_Edit_BirthplaceFieldText:SetText(loc.REG_PLAYER_BIRTHPLACE);
 
-	Events.listenToEvent(Events.REGISTER_PROFILES_LOADED, compressData); -- On profile change, compress the new data
-	compressData();
 
 	-- Resizing
 	TRP3_API.events.listenToEvent(TRP3_API.events.NAVIGATION_RESIZED, function(containerwidth, containerHeight)

--- a/totalRP3/modules/register/companions/register_companions_page.lua
+++ b/totalRP3/modules/register/companions/register_companions_page.lua
@@ -173,7 +173,6 @@ local function saveInformation()
 	-- version increment
 	dataTab.data.v = Utils.math.incrementNumber(dataTab.data.v or 0, 2);
 
-	--	compressData();
 	Events.fireEvent(Events.REGISTER_DATA_UPDATED, nil, context.profileID);
 end
 


### PR DESCRIPTION
With 8.0 and profile exchange being logged, compression has now been banned by the Geneva Convention. I removed all instances of it.

A small commented function was caught in the crossfire and is an unfortunate collateral. May its soul rest in peace.