### PR TITLE
Fixed API calls

### DIFF
--- a/totalRP3/core/impl/CommunicationProtocol.lua
+++ b/totalRP3/core/impl/CommunicationProtocol.lua
@@ -260,8 +260,8 @@ Ellyb.Documentation:AddDocumentationTable("TotalRP3_Communication", {
 -- DEPRECATED
 -- Backward compatibility layer
 TRP3_API.communication = {};
-TRP3_API.communication.getMessageIDAndIncrement = Ellyb.DeprecationWarnings.wrapFunction(getNewMessageToken, "TRP3_API.communication.getMessageIDAndIncrement", "AddOn_TotalRP3.Communication.getNewMessageToken");
-TRP3_API.communication.registerProtocolPrefix = Ellyb.DeprecationWarnings.wrapFunction(registerSubSystemPrefix, "TRP3_API.communication.registerProtocolPrefix", "AddOn_TotalRP3.Communication.registerSubSystemPrefix");
+TRP3_API.communication.getMessageIDAndIncrement = Ellyb.DeprecationWarnings.wrapFunction(getNewMessageToken, "TRP3_API.communication.getMessageIDAndIncrement", "AddOn_TotalRP3.Communications.getNewMessageToken");
+TRP3_API.communication.registerProtocolPrefix = Ellyb.DeprecationWarnings.wrapFunction(registerSubSystemPrefix, "TRP3_API.communication.registerProtocolPrefix", "AddOn_TotalRP3.Communications.registerSubSystemPrefix");
 
 TRP3_API.communication.addMessageIDHandler = function(sender, reservedMessageID, callback)
 	Ellyb.DeprecationWarnings.warn([[Deprecated usage of TRP3_API.communication.addMessageIDHandler(sender, reservedMessageID, callback). You should now provide an onProgression callback when using AddOn_TotalRP3.registerSubSystemPrefix(prefix, callback, onProgressCallback) for the sub-system. This callback will be called with the message ID in the parameters.]]);
@@ -272,6 +272,6 @@ TRP3_API.communication.addMessageIDHandler = function(sender, reservedMessageID,
 	end);
 end
 
-Ellyb.DeprecationWarnings.wrapAPI(AddOn_TotalRP3.Communications, "TRP3_API.communication", "AddOn_TotalRP3.Communication", TRP3_API.communication);
+Ellyb.DeprecationWarnings.wrapAPI(AddOn_TotalRP3.Communications, "TRP3_API.communication", "AddOn_TotalRP3.Communications", TRP3_API.communication);
 
 

--- a/totalRP3/core/impl/ProfilesChatLinksModule.lua
+++ b/totalRP3/core/impl/ProfilesChatLinksModule.lua
@@ -32,7 +32,7 @@ local isType = Ellyb.Assertions.isType;
 -- Total RP 3 imports
 local loc = TRP3_API.loc;
 local tcopy = TRP3_API.utils.table.copy;
-local Globals = TRP3_API.Globals;
+local Globals = TRP3_API.globals;
 local Utils = TRP3_API.utils;
 local Events = TRP3_API.events;
 

--- a/totalRP3/core/impl/slash.lua
+++ b/totalRP3/core/impl/slash.lua
@@ -101,12 +101,12 @@ end
 
 local function sendDiceRoll(args)
 	if isTargetValidForDiceRoll() then
-		TRP3_API.Communication.sendObject(DICE_SIGNAL, args, Utils.str.getUnitID("target"));
+		TRP3_API.communication.sendObject(DICE_SIGNAL, args, Utils.str.getUnitID("target"));
 	end
 	if IsInRaid() then
-		TRP3_API.Communication.sendObject(DICE_SIGNAL, args, "RAID");
+		TRP3_API.communication.sendObject(DICE_SIGNAL, args, "RAID");
 	elseif IsInGroup() then
-		TRP3_API.Communication.sendObject(DICE_SIGNAL, args, "PARTY");
+		TRP3_API.communication.sendObject(DICE_SIGNAL, args, "PARTY");
 	end
 end
 

--- a/totalRP3/core/impl/slash.lua
+++ b/totalRP3/core/impl/slash.lua
@@ -101,12 +101,12 @@ end
 
 local function sendDiceRoll(args)
 	if isTargetValidForDiceRoll() then
-		TRP3_API.communication.sendObject(DICE_SIGNAL, args, Utils.str.getUnitID("target"));
+		AddOn_TotalRP3.Communications.sendObject(DICE_SIGNAL, args, Utils.str.getUnitID("target"));
 	end
 	if IsInRaid() then
-		TRP3_API.communication.sendObject(DICE_SIGNAL, args, "RAID");
+		AddOn_TotalRP3.Communications.sendObject(DICE_SIGNAL, args, "RAID");
 	elseif IsInGroup() then
-		TRP3_API.communication.sendObject(DICE_SIGNAL, args, "PARTY");
+		AddOn_TotalRP3.Communications.sendObject(DICE_SIGNAL, args, "PARTY");
 	end
 end
 

--- a/totalRP3/modules/ChatLinks/ChatLinkActionButton.lua
+++ b/totalRP3/modules/ChatLinks/ChatLinkActionButton.lua
@@ -102,7 +102,7 @@ function ChatLinkActionButton:OnClick(linkID, sender, button)
 		local messageToken = TRP3_API.communication.getMessageIDAndIncrement();
 		self.messageToken = messageToken;
 		-- Send a request for this link ID and indicate a message ID to use for progression updates
-		TRP3_API.Communication.sendObject(_private[self].questionCommand, {
+		TRP3_API.communication.sendObject(_private[self].questionCommand, {
 			linkID = linkID,
 			messageID = messageToken,
 		}, sender);

--- a/totalRP3/modules/ChatLinks/ChatLinkActionButton.lua
+++ b/totalRP3/modules/ChatLinks/ChatLinkActionButton.lua
@@ -99,10 +99,10 @@ function ChatLinkActionButton:OnClick(linkID, sender, button)
 		button:SetText(loc.CL_SENDING_COMMAND);
 		button:Disable();
 		-- Get a unique message identifier for the data request, used for progression updates
-		local messageToken = TRP3_API.communication.getMessageIDAndIncrement();
+		local messageToken = AddOn_TotalRP3.Communications.getNewMessageToken();
 		self.messageToken = messageToken;
 		-- Send a request for this link ID and indicate a message ID to use for progression updates
-		TRP3_API.communication.sendObject(_private[self].questionCommand, {
+		AddOn_TotalRP3.Communications.sendObject(_private[self].questionCommand, {
 			linkID = linkID,
 			messageID = messageToken,
 		}, sender);

--- a/totalRP3/modules/register/characters/register_about.lua
+++ b/totalRP3/modules/register/characters/register_about.lua
@@ -22,7 +22,7 @@
 local _, TRP3_API = ...;
 
 -- imports
-local Globals, Utils, Comm, Events = TRP3_API.globals, TRP3_API.utils, TRP3_API.Communication, TRP3_API.events;
+local Globals, Utils, Comm, Events = TRP3_API.globals, TRP3_API.utils, TRP3_API.communication, TRP3_API.events;
 local stEtN = Utils.str.emptyToNil;
 local get = TRP3_API.profile.getData;
 local safeGet = TRP3_API.profile.getDataDefault;

--- a/totalRP3/modules/register/characters/register_about.lua
+++ b/totalRP3/modules/register/characters/register_about.lua
@@ -22,7 +22,7 @@
 local _, TRP3_API = ...;
 
 -- imports
-local Globals, Utils, Comm, Events = TRP3_API.globals, TRP3_API.utils, TRP3_API.communication, TRP3_API.events;
+local Globals, Utils, Comm, Events = TRP3_API.globals, TRP3_API.utils, AddOn_TotalRP3.Communications, TRP3_API.events;
 local stEtN = Utils.str.emptyToNil;
 local get = TRP3_API.profile.getData;
 local safeGet = TRP3_API.profile.getDataDefault;

--- a/totalRP3/modules/register/main/RegisterPlayerChatLinksModule.lua
+++ b/totalRP3/modules/register/main/RegisterPlayerChatLinksModule.lua
@@ -31,7 +31,7 @@ local isType = Ellyb.Assertions.isType;
 -- Total RP 3 imports
 local loc = TRP3_API.loc;
 local tcopy = TRP3_API.utils.table.copy;
-local Globals = TRP3_API.Globals;
+local Globals = TRP3_API.globals;
 local Utils = TRP3_API.utils;
 local Events = TRP3_API.events;
 


### PR DESCRIPTION
There were some issues with creating profile links, sending the roll result event, and importing/adding an item to the inventory. After investigating, there were a couple of incorrect uppercases for the `TRP3_API.globals` call, and some `TRP3_API.Communication` or `Addon_TotalRP3.Communication` calls which don't exist (It's `Addon_TotalRP3.Communications`)

Fixed this nice and clean.