### PR TITLE
Fixed directory selection bugs (#160)

### DIFF
--- a/totalRP3/modules/register/characters/register_ignore.lua
+++ b/totalRP3/modules/register/characters/register_ignore.lua
@@ -155,7 +155,7 @@ end
 
 function TRP3_API.register.unignoreID(unitID)
 	blackList[unitID] = nil;
-	Events.fireEvent(Events.REGISTER_DATA_UPDATED, unitID, hasProfile(unitID), nil);
+	Events.fireEvent(Events.REGISTER_DATA_UPDATED, unitID, TRP3_API.register.isUnitIDKnown(unitID) and hasProfile(unitID) or nil, nil);
 end
 
 function TRP3_API.register.getIgnoredList()

--- a/totalRP3/modules/register/main/register_list.lua
+++ b/totalRP3/modules/register/main/register_list.lua
@@ -493,9 +493,10 @@ local function onCharactersActionSelected(value, button)
 	elseif value == "actions_delete" then
 		showConfirmPopup(loc.REG_LIST_ACTIONS_MASS_REMOVE_C:format(tsize(selectedIDs)), function()
 			for profileID, _ in pairs(selectedIDs) do
-				deleteProfile(profileID);
+				deleteProfile(profileID, true);
 			end
 			Events.fireEvent(Events.REGISTER_DATA_UPDATED);
+			Events.fireEvent(Events.REGISTER_PROFILE_DELETED);
 			refreshList();
 		end);
 	elseif value == "actions_ignore" then
@@ -910,6 +911,13 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 			if isMenuRegistered(currentlyOpenedProfilePrefix .. profileID) then
 				unregisterMenu(currentlyOpenedProfilePrefix .. profileID);
 			end
+		else
+			for profileID, _ in pairs(selectedIDs) do
+				if isMenuRegistered(currentlyOpenedProfilePrefix .. profileID) then
+					unregisterMenu(currentlyOpenedProfilePrefix .. profileID);
+				end
+			end
+			wipe(selectedIDs);
 		end
 		if getCurrentPageID() == REGISTER_LIST_PAGEID then
 			refreshList();

--- a/totalRP3/modules/register/main/register_list.lua
+++ b/totalRP3/modules/register/main/register_list.lua
@@ -808,7 +808,11 @@ end
 
 local function onLineSelected(self, button)
 	assert(self:GetParent().id, "No id on line.");
-	selectedIDs[self:GetParent().id] = self:GetChecked();
+	local newValue = self:GetChecked();
+	if not newValue then
+		newValue = nil;
+	end
+	selectedIDs[self:GetParent().id] = newValue;
 end
 
 local function changeMode(tabWidget, value)

--- a/totalRP3/modules/register/main/register_list.lua
+++ b/totalRP3/modules/register/main/register_list.lua
@@ -807,11 +807,7 @@ end
 
 local function onLineSelected(self, button)
 	assert(self:GetParent().id, "No id on line.");
-	local newValue = self:GetChecked();
-	if not newValue then
-		newValue = nil;
-	end
-	selectedIDs[self:GetParent().id] = newValue;
+	selectedIDs[self:GetParent().id] = self:GetChecked() or nil;
 end
 
 local function changeMode(tabWidget, value)

--- a/totalRP3/modules/register/main/register_list.lua
+++ b/totalRP3/modules/register/main/register_list.lua
@@ -477,6 +477,8 @@ local function onCharactersActionSelected(value, button)
 				for _, unitID in pairs(characterToPurge) do
 					deleteCharacter(unitID);
 				end
+				Events.fireEvent(Events.REGISTER_DATA_UPDATED);
+				Events.fireEvent(Events.REGISTER_PROFILE_DELETED);
 				refreshList();
 			end);
 		end

--- a/totalRP3/modules/register/main/register_list.lua
+++ b/totalRP3/modules/register/main/register_list.lua
@@ -493,10 +493,9 @@ local function onCharactersActionSelected(value, button)
 	elseif value == "actions_delete" then
 		showConfirmPopup(loc.REG_LIST_ACTIONS_MASS_REMOVE_C:format(tsize(selectedIDs)), function()
 			for profileID, _ in pairs(selectedIDs) do
-				deleteProfile(profileID, true);
+				deleteProfile(profileID);
 			end
 			Events.fireEvent(Events.REGISTER_DATA_UPDATED);
-			Events.fireEvent(Events.REGISTER_PROFILE_DELETED);
 			refreshList();
 		end);
 	elseif value == "actions_ignore" then


### PR DESCRIPTION
Selected profiles are detected by setting the value indexed to the profile ID to `true` in the array (which starts empty) when selecting it, and iterating on the array elements to make an action.

The first issue comes from the deselection setting the value to `false` instead of `nil`. The array still has a value for it, so considers it selected still (and the array size still takes it into account).

The second issue came from the fact the deletion of multiple selected profiles wasn't firing an event for every profile deleted, but only a general one which wouldn't update the selected profiles array.

**I think there might still be a potential issue if you select profiles then purge.** I'm not sure if purges should trigger the event per profile purged, although the event seems to be clearing some array in MSP if the profile was received through it. If not, at the very least the selected profiles array should be wiped after a purge. Let me know what to do about that.