### PR TITLE
Fixed mount profiles not shown on other players

### DIFF
--- a/totalRP3/modules/register/companions/register_companions_main.lua
+++ b/totalRP3/modules/register/companions/register_companions_main.lua
@@ -427,9 +427,9 @@ end
 
 function TRP3_API.companions.register.getUnitMount(ownerID, unitType)
 	local buffIndex = 1;
-	local spellBuffID = select(11, UnitAura(unitType, buffIndex));
+	local spellBuffID = select(10, UnitAura(unitType, buffIndex));
 	while(spellBuffID) do
-		spellBuffID = select(11, UnitAura(unitType, buffIndex));
+		spellBuffID = select(10, UnitAura(unitType, buffIndex));
 		local companionFullID = ownerID .. "_" .. tostring(spellBuffID);
 		if registerProfileAssociation[companionFullID] then
 			return companionFullID, registerProfileAssociation[companionFullID], tostring(spellBuffID);


### PR DESCRIPTION
As suspected, the removal of the 2nd return value is the reason mount profiles weren't shown on other characters. The ID we're looking for is now the 10th return value.