### PR TITLE
Added target frame update on mount/dismount

### DIFF
--- a/totalRP3/modules/targetframe/target_frame.lua
+++ b/totalRP3/modules/targetframe/target_frame.lua
@@ -374,6 +374,7 @@ local function onStart()
 	companionHasProfile = TRP3_API.companions.register.companionHasProfile;
 
 	Utils.event.registerHandler("PLAYER_TARGET_CHANGED", onTargetChanged);
+	Utils.event.registerHandler("PLAYER_MOUNT_DISPLAY_CHANGED", onTargetChanged);
 	Events.listenToEvent(Events.REGISTER_ABOUT_READ, onTargetChanged);
 	Events.listenToEvent(Events.REGISTER_DATA_UPDATED, function(unitID, profileID, dataType)
 		if (not unitID or (currentTargetID == unitID)) and (not dataType or dataType == "characteristics" or dataType == "about") then


### PR DESCRIPTION
When having yourself as the target, mounting or dismounting wasn't updating the target frame. This means, if you targeted yourself mounted then dismounted, you would still have the button to edit your mount's profile, which would return an error upon clicking it since you don't have an active mount anymore.

I just added a target frame refresh on mounting/dismounting. If you feel like it's overkill, I can add a function to only update if the current frame is the player's.