### PR TITLE
Linebreak filtering in tooltip currently and OOC fields

### DIFF
--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1266,7 +1266,7 @@ Please keep in mind that changing those settings might alter your experience wit
 	--- THEN MOVE IT UP ONCE IMPORTED
 	------------------------------------------------------------------------------------------------
 
-	CO_TOOLTIP_CURRENT_LINES = "Max \"current\" lines count",
+	CO_TOOLTIP_CURRENT_LINES = "Max \"current\" line breaks",
 };
 
 -- Use Ellyb to generate the Localization system

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1266,6 +1266,7 @@ Please keep in mind that changing those settings might alter your experience wit
 	--- THEN MOVE IT UP ONCE IMPORTED
 	------------------------------------------------------------------------------------------------
 
+	CO_TOOLTIP_CURRENT_LINES = "Max \"current\" lines count",
 };
 
 -- Use Ellyb to generate the Localization system


### PR DESCRIPTION
Character limit does a good work but it is still possible to spam line breaks to make the tooltip overly high. This adds a filter with customizable limit on the number of max lines to allow in currently & OOC fields (5 by default).

Meorawr did all the stuff but I'm stealing the glory anyway.

April Fools code has been removed due to reaching the upvalue limit in the tooltip builder, which is an issue that will need to be resolved later.