### PR TITLE
MSP to TRP profile fixes

### DIFF
--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -181,7 +181,7 @@ local function onStart()
 		RA = "RA",
 		RC = "CL",
 		AG = "AG",
-		AE = "AE",
+		AE = "EC",
 		AH = "HE",
 		AW = "WE",
 		HH = "RE",

--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -259,6 +259,20 @@ local function onStart()
 						value = value:gsub("|c%x%x%x%x%x%x%x%x", "");
 						profile.characteristics["CH"] = color;
 					end
+					-- EC color escaping
+					if field == "AE" and value then
+						local color;
+						value:gsub("|c%x%x(%x%x%x%x%x%x)", function(arg1)
+							if not color then color = arg1 end
+							return "";
+						end);
+						value = value:gsub("|c%x%x%x%x%x%x%x%x", "");
+						profile.characteristics["EH"] = color;
+					end
+					-- RC color escaping
+					if field == "RC" and value then
+						value = value:gsub("|c%x%x%x%x%x%x%x%x", "");
+					end
 					-- We do not want to trim the class field
 					-- Some users are using a space to indicate they don't have a class
 					if not CHARACTERISTICS_FIELDS[field] == "CL" then


### PR DESCRIPTION
- Main reason for this PR : The AE field received from a MSP profile was stored in the AE field in TRP's characteristics page, except the eye color field is EC in TRP, so that was never displayed.

- For the second commit, I've peered into the future and MRP will send name, class and eye color with color tags sometimes. While the name color was escaped and stored into the proper field, class and eye color weren't. I suggest adding that preemptively. As of now, MRP class color will work the same way as TRP (same as name).