### PR TITLE
When sending a dice roll, the modifierValue is now included.

### DIFF
--- a/totalRP3/core/impl/slash.lua
+++ b/totalRP3/core/impl/slash.lua
@@ -131,7 +131,7 @@ local function rollDice(diceString, noSend)
 		total = total + modifierValue;
 
 		Utils.message.displayMessage(loc.DICE_ROLL:format(Utils.str.icon("inv_misc_dice_02", 20), num, diceCount, total));
-		sendDiceRoll({c = num, d = diceCount, t = total});
+		sendDiceRoll({c = num, d = diceCount, t = total, m = modifierValue});
 		return total;
 	end
 	return 0;


### PR DESCRIPTION
This allows DM add-ons to confirm that the user is not using the wrong modifier when the result is within the expected range
This will be ignored in all other cases without impact beyond message size