### PR TITLE
sendObject function now handles both Channel type and numbered channels

### DIFF
--- a/totalRP3/core/impl/CommunicationProtocol.lua
+++ b/totalRP3/core/impl/CommunicationProtocol.lua
@@ -129,18 +129,18 @@ local function unregisterMessageTokenProgressHandler(handlerID)
 end
 
 local function sendObject(prefix, object, channel, target, priority, messageToken, useLoggedMessages)
-	if not tContains(validChannels, channel) then
+	if not tContains(VALID_CHANNELS, channel) then
 		--if channel is ignored, default channel and bump everything along by one
 		channel, target, priority, messageToken, useLoggedMessages = "WHISPER", channel, target, priority, messageToken
 	end
-	if tContains(validPriorities, target) then
+	if tContains(VALID_PRIORITIES, target) then
 		-- if target has values expected for priority, bump everything back by one
 		target, priority, messageToken, useLoggedMessages = nil, target, priority, messageToken
 	end
 
 	assert(isType(prefix, "string", "prefix"));
 	assert(subSystemsDispatcher:HasCallbacksForEvent(prefix), "Unregistered prefix: "..prefix);
-	assert(isOneOf(channel, validChannels, "channel"));
+	assert(isOneOf(channel, VALID_CHANNELS, "channel"));
 
 	if not TRP3_API.register.isIDIgnored(target) then
 
@@ -149,7 +149,7 @@ local function sendObject(prefix, object, channel, target, priority, messageToke
 		end
 		priority = CTLToChompPriority(priority);
 
-		assert(isOneOf(priority, validPriorities, "priority"));
+		assert(isOneOf(priority, VALID_PRIORITIES, "priority"));
 
 		messageToken = messageToken or getNewMessageToken();
 

--- a/totalRP3/core/impl/CommunicationProtocol.lua
+++ b/totalRP3/core/impl/CommunicationProtocol.lua
@@ -30,6 +30,7 @@ local assert = assert;
 local string = string;
 local math = math;
 local tostring = tostring;
+local tContains = tContains;
 --endregion
 
 -- AddOn imports
@@ -38,7 +39,6 @@ local logger = Ellyb.Logger("TotalRP3_Communication");
 local isType = Ellyb.Assertions.isType;
 local isOneOf = Ellyb.Assertions.isOneOf;
 local isNotNil = Ellyb.Assertions.isNotNil;
-local containsValue = Ellyb.Tables.containsValue;
 
 -- Total RP 3 imports
 local Compression = AddOn_TotalRP3.Compression;
@@ -126,11 +126,11 @@ local function unregisterMessageTokenProgressHandler(handlerID)
 end
 
 local function sendObject(prefix, object, channel, target, priority, messageToken, useLoggedMessages)
-	if not containsValue({"PARTY", "RAID", "GUILD", "BATTLEGROUND", "WHISPER", "CHANNEL"}, channel) then
+	if not tContains({"PARTY", "RAID", "GUILD", "BATTLEGROUND", "WHISPER", "CHANNEL"}, channel) then
 		--if channel is ignored, default channel and bump everything along by one
 		channel, target, priority, messageToken, useLoggedMessages = "WHISPER", channel, target, priority, messageToken
 	end
-	if containsValue({"HIGH", "MEDIUM", "LOW"}, target) then
+	if tContains({"HIGH", "MEDIUM", "LOW"}, target) then
 		-- if target has values expected for priority, bump everything back by one
 		target, priority, messageToken, useLoggedMessages = nil, target, priority, messageToken
 	end

--- a/totalRP3/core/impl/CommunicationProtocol.lua
+++ b/totalRP3/core/impl/CommunicationProtocol.lua
@@ -60,8 +60,8 @@ local PRIORITIES = {
 	HIGH = "HIGH",
 }
 
-local validChannels = {"PARTY", "RAID", "GUILD", "BATTLEGROUND", "WHISPER", "CHANNEL"};
-local validPriorities = {"HIGH", "MEDIUM", "LOW"};
+local VALID_CHANNELS = {"PARTY", "RAID", "GUILD", "BATTLEGROUND", "WHISPER", "CHANNEL"};
+local VALID_PRIORITIES = {"HIGH", "MEDIUM", "LOW"};
 
 local subSystemsDispatcher = Ellyb.EventsDispatcher();
 local subSystemsOnProgressDispatcher = Ellyb.EventsDispatcher();


### PR DESCRIPTION
This allows DM add-ons to confirm that the user is not using the wrong modifier when the result is within the expected range
This will be ignored in all other cases without impact beyond message size