### PR TITLE
Macro conditionals for /trp commands

### DIFF
--- a/totalRP3/core/impl/slash.lua
+++ b/totalRP3/core/impl/slash.lua
@@ -275,6 +275,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 			profileName = string.lower(profileName);--we lowercase it all
 			profileName = string.gsub(profileName, "[^%s%a]", "");--remove anything that's not a letter or space)
 			profileName = string.gsub(profileName,"(%s)(%a)", function(a,b) return string.upper(b) end) -- and turn it into a camelCaseValue
+			profileName = string.gsub(profileName, "%s", ""); --and clean up any remaining spaces
 			return profileName==targetProfile; --then compare it to the given string
 		end
 	})

--- a/totalRP3/core/impl/slash.lua
+++ b/totalRP3/core/impl/slash.lua
@@ -100,7 +100,6 @@ local function parseCommandTable(args)
 end
 
 local function testConditions(conditionals)
-	logger:Info(Ellyb.Tables.toString(conditionals));
 	local conditionalsPassed = false;
 	for _, condition in pairs(conditionals) do
 		--cleanup the square brackets to give us a comma seperated lsit of tests
@@ -128,13 +127,12 @@ local function testConditions(conditionals)
 end
 
 function SlashCmdList.TOTALRP3(msg, editbox)
-
 	if not string.match(msg, "%[[^%;%[%]]*%]") then
 		--we don't have any conditionals, so trigger the old code
 		local args = {strsplit(" ", msg)};
 		return parseCommandTable(args);
 	end
-	logger:Info(msg);
+
 	for segment in string.gmatch(msg, "(%b[] ?[^%;%[%]]*)") do
 		local segmentConditionals = {string.match(segment, "%[([^%;%[%]]*)%] ?([^%;%[%]]*)")};
 		local segmentCommand = segmentConditionals[#segmentConditionals];
@@ -143,9 +141,8 @@ function SlashCmdList.TOTALRP3(msg, editbox)
 			return parseCommandTable({strsplit(" ", segmentCommand)})
 		end
 	end
-	logger:Info("Last");
+
 	local unconditionalCommand = string.match(msg, "%; ?([^;%]]+)$")
-	logger:Info(unconditionalCommand)
 	if unconditionalCommand then
 		return parseCommandTable({strsplit(" ", unconditionalCommand, nil)});
 	end


### PR DESCRIPTION
All vanilla conditonals are supported by SecureCmdOptionParse
Additional commands are supported and can be added by the use of TRP3_API.slash.registerConditional
Added commands also get the "no" inversion of regular macros.
Additional comands included by default are:
[ic][ooc] to test for IC/OOC status
[location:locationName][loc:locationName] to test if the player is in a specific location (as reported by the minimap)
[profile:profileName] to test for a specific selected profile. Profile names are sanitised of all punctuation and converted into camelcase. As such the profile "bob's profile" and "bobs profile" would both pass the same check of "bobsProfile"

Addresses ticket https://github.com/Ellypse/Total-RP-3/issues/124