### PR TITLE
Fixed issue with glance frame reset + removed useless setting

### DIFF
--- a/totalRP3/modules/flyway/flyway_patches.lua
+++ b/totalRP3/modules/flyway/flyway_patches.lua
@@ -106,7 +106,9 @@ end
 
 -- Reset glance bar coordinates
 TRP3_API.flyway.patches["9"] = function()
-	if TRP3_API.register.resetGlanceBar then
-		TRP3_API.register.resetGlanceBar();
-	end
+	TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_FINISH, function()
+		if TRP3_API.register.resetGlanceBar then
+			TRP3_API.register.resetGlanceBar();
+		end
+	end)
 end

--- a/totalRP3/modules/register/main/register_glance.lua
+++ b/totalRP3/modules/register/main/register_glance.lua
@@ -734,13 +734,6 @@ local function onStart()
 		ui_GlanceBar:SetPoint("BOTTOM", parentFrame, "BOTTOM", getConfigValue(CONFIG_GLANCE_ANCHOR_X) / parentScale, getConfigValue(CONFIG_GLANCE_ANCHOR_Y) / parentScale);
 	end
 
-	local function resetPosition()
-		setConfigValue(CONFIG_GLANCE_PARENT, "TRP3_TargetFrame");
-		setConfigValue(CONFIG_GLANCE_ANCHOR_X, 0);
-		setConfigValue(CONFIG_GLANCE_ANCHOR_Y, -14);
-		replaceBar();
-	end
-
 	-- Function called when the glance bar is dragged
 	local function glanceBar_DraggingFrame_OnUpdate(self)
 		if not getConfigValue(CONFIG_GLANCE_LOCK) and self.isDraging then
@@ -774,6 +767,7 @@ local function onStart()
 		setConfigValue(CONFIG_GLANCE_PARENT, "TRP3_TargetFrame");
 		setConfigValue(CONFIG_GLANCE_ANCHOR_X, 0);
 		setConfigValue(CONFIG_GLANCE_ANCHOR_Y, -14);
+		replaceBar();
 	end
 
 	-- Config must be built on WORKFLOW_ON_LOADED or else the TargetFrame module could be not yet loaded.
@@ -798,7 +792,7 @@ local function onStart()
 			title = loc.CO_MINIMAP_BUTTON_RESET,
 			help = loc.CO_GLANCE_RESET_TT,
 			text = loc.CO_MINIMAP_BUTTON_RESET_BUTTON,
-			callback = resetPosition,
+			callback = TRP3_API.register.resetGlanceBar,
 		});
 		tinsert(TRP3_API.configuration.CONFIG_FRAME_PAGE.elements, {
 			inherit = "TRP3_ConfigButton",
@@ -812,20 +806,6 @@ local function onStart()
 				replaceBar();
 			end,
 		});
-		if TRP3_API.target then
-			tinsert(TRP3_API.configuration.CONFIG_FRAME_PAGE.elements, {
-				inherit = "TRP3_ConfigButton",
-				title = loc.CO_GLANCE_PRESET_TRP3,
-				text = loc.CO_GLANCE_PRESET_TRP2_BUTTON,
-				help = loc.CO_GLANCE_PRESET_TRP3_HELP,
-				callback = function()
-					setConfigValue(CONFIG_GLANCE_PARENT, "TRP3_TargetFrame");
-					setConfigValue(CONFIG_GLANCE_ANCHOR_X, 0);
-					setConfigValue(CONFIG_GLANCE_ANCHOR_Y, -14);
-					replaceBar();
-				end,
-			});
-		end
 		tinsert(TRP3_API.configuration.CONFIG_FRAME_PAGE.elements, {
 			inherit = "TRP3_ConfigDropDown",
 			widgetName = "TRP3_ConfigurationTooltip_GlanceTT_Anchor",


### PR DESCRIPTION
So, some weird stuff going on. It turns out `TRP3_API.register.resetGlanceBar` was only updating the config settings and not the actual frame, so the right position wouldn't be seen until reload.
The button to reset was calling the local `resetPosition` instead, which would update the frame.
And in the config settings, there was a button to use Total RP 3 style positions, just below the reset button, doing exactly the same thing as the reset button, not even using `resetPosition` but a local function with the exact same code.

I added the frame update to `TRP3_API.register.resetGlanceBar`, removed `resetPosition` and replaced the function called by the reset button, and removed the button to use TRP3 style position. As an added bonus, just to be sure, I wait for the loading workflow to finish before resetting the glance bar. Not sure it's needed but doesn't hurt.