### PR TITLE
Fixed sorting between string and nil priorities

### DIFF
--- a/totalRP3/modules/map/MapPoiMixins.lua
+++ b/totalRP3/modules/map/MapPoiMixins.lua
@@ -72,6 +72,12 @@ local function sortMarkerEntries(a, b)
 	local categoryA = a.categoryPriority or huge;
 	local categoryB = b.categoryPriority or huge;
 
+	if categoryA == huge and type(categoryB) == "string" then
+		categoryA = "";
+	elseif categoryB == huge and type(categoryA) == "string" then
+		categoryB = "";
+	end
+
 	local nameA = a.sortName or "";
 	local nameB = b.sortName or "";
 


### PR DESCRIPTION
If one of the categories has a string priority and the other is nil, the nil priority is set to "" so the comparison doesn't bug out.
Should we have a safeguard against comparisons between number and string as well ?