### PR TITLE
Added nil check when trying to restore saved language

### DIFF
--- a/totalRP3/modules/chatframe/languages.lua
+++ b/totalRP3/modules/chatframe/languages.lua
@@ -159,7 +159,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 
 	local function checkCurrentLanguageAndRestoreSavedState()
 		local savedLanguage = Languages.getSavedLanguage()
-		if not savedLanguage:IsKnown() then
+		if not savedLanguage or not savedLanguage:IsKnown() then
 			local defaultLanguage = Languages.getDefaultLanguage()
 			Languages.setLanguage(defaultLanguage)
 			TRP3_API.utils.message.displayMessage(loc.LANG_CHANGE_CAUSED_REVERT_TO_DEFAULT:format(defaultLanguage:GetName(), savedLanguage:GetName()))


### PR DESCRIPTION
`Languages.getSavedLanguage` can return nothing which will error out when trying to call IsKnown on it. Restoring the savedLanguage now checks that we have a language saved in addition to check if it is known (putting the default language if not).