### PR TITLE
Bugfix/#237 disable map location when ooc doesnt work

### DIFF
--- a/totalRP3/core/Models/Player.lua
+++ b/totalRP3/core/Models/Player.lua
@@ -135,9 +135,10 @@ function Player:IsCurrentUser()
 end
 
 function Player:IsInCharacter()
-	return self:GetInfo("player/character/RP") ~= 2
+	return self:GetInfo("character/RP") ~= 2
 end
 
+-- TODO Deprecate GetInfo(path) in favor of proper type safe methods to access profile data
 function Player:GetInfo(path)
 	return TRP3_API.profile.getData(path, self:GetProfile())
 end


### PR DESCRIPTION
Fixed issue with `Player` model preventing from receiving a valid value from `IsInCharacter()`