### PR TITLE
#248 Use C_ChatInfo.SwapChatChannelsByChannelIndex

### DIFF
--- a/totalRP3/core/impl/communication_protocol_broadcast.lua
+++ b/totalRP3/core/impl/communication_protocol_broadcast.lua
@@ -260,7 +260,7 @@ local function moveBroadcastChannelToTheBottomOfTheList()
 		for channelIndex = 1, MAX_WOW_CHAT_CHANNELS do
 			local _, channelName = GetChannelName(channelIndex);
 			if channelName == broadcastChannelName then
-				SwapChatChannelByLocalID(channelIndex, channelIndex + 1);
+				(SwapChatChannelByLocalID and SwapChatChannelByLocalID or C_ChatInfo.SwapChatChannelsByChannelIndex)(channelIndex, channelIndex + 1);
 			end
 		end
 

--- a/totalRP3/core/impl/communication_protocol_broadcast.lua
+++ b/totalRP3/core/impl/communication_protocol_broadcast.lua
@@ -260,7 +260,7 @@ local function moveBroadcastChannelToTheBottomOfTheList()
 		for channelIndex = 1, MAX_WOW_CHAT_CHANNELS do
 			local _, channelName = GetChannelName(channelIndex);
 			if channelName == broadcastChannelName then
-				(SwapChatChannelByLocalID and SwapChatChannelByLocalID or C_ChatInfo.SwapChatChannelsByChannelIndex)(channelIndex, channelIndex + 1);
+				(SwapChatChannelByLocalID or C_ChatInfo.SwapChatChannelsByChannelIndex)(channelIndex, channelIndex + 1);
 			end
 		end
 


### PR DESCRIPTION
Use `C_ChatInfo.SwapChatChannelsByChannelIndex` if `SwapChatChannelByLocalID` is not available.
Fixes #248