### PR TITLE
Bugfix/#227 individual character informations in the directory are never purged

### DIFF
--- a/totalRP3/modules/register/characters/register_main.lua
+++ b/totalRP3/modules/register/characters/register_main.lua
@@ -248,6 +248,7 @@ function TRP3_API.register.saveCurrentProfileID(unitID, currentProfileID, isMSP)
 	local profile = getProfile(currentProfileID);
 	profile.link[unitID] = 1; -- bound
 	profile.msp = isMSP;
+	profile.time = time()
 
 	if oldProfileID ~= currentProfileID then
 		Events.fireEvent(Events.REGISTER_DATA_UPDATED, unitID, currentProfileID, nil);

--- a/totalRP3/modules/register/characters/register_main.lua
+++ b/totalRP3/modules/register/characters/register_main.lua
@@ -525,6 +525,12 @@ local function cleanupCharacters()
 			character.profileID = nil;
 		end
 	end
+	for unitID, character in pairs(characters) do
+		if not character.profileID and not TRP3_API.register.isIDIgnored(unitID) then
+			wipe(character)
+			characters[unitID] = nil
+		end
+	end
 end
 
 local function cleanupCompanions()


### PR DESCRIPTION
Delete characters info from the database if we no longer have a profile associated to them and they are not in the ignore list. Before, the characters table would never be cleaned and would fill up indefinitely.

Also fixed an issue where profiles that were just freshly downloaded would be purged after a /reload because the `time` field used for the purge would only be created on the next mouseover on the profile owner. Now when we create or update a profile we update the time field too. This should also keep profiles downloaded from chat links in the directory.