### PR TITLE
Removed "Use template 3 only" setting

### DIFF
--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -34,7 +34,6 @@ local function onStart()
 	local getConfigValue, registerConfigKey, registerConfigHandler = TRP3_API.configuration.getValue, TRP3_API.configuration.registerConfigKey, TRP3_API.configuration.registerHandler;
 	local get, getCompleteName = TRP3_API.profile.getData, TRP3_API.register.getCompleteName;
 	local isIgnored = TRP3_API.register.isIDIgnored;
-	local CONFIG_T3_ONLY = "msp_t3";
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	-- LibMSP support code
@@ -78,7 +77,7 @@ local function onStart()
 		msp.my['DE'] = nil;
 		msp.my['HI'] = nil;
 
-		if getConfigValue(CONFIG_T3_ONLY) or dataTab.TE == 3 then
+		if dataTab.TE == 3 then
 			msp.my['HI'] = removeTextTags(dataTab.T3.HI.TX);
 			local PH = removeTextTags(dataTab.T3.PH.TX) or "";
 			local PS = removeTextTags(dataTab.T3.PS.TX) or "";
@@ -544,17 +543,9 @@ local function onStart()
 	end
 
 	-- Build configuration page
-	registerConfigKey(CONFIG_T3_ONLY, false);
-	registerConfigHandler(CONFIG_T3_ONLY, onAboutChanged);
 	tinsert(TRP3_API.register.CONFIG_STRUCTURE.elements, {
 		inherit = "TRP3_ConfigH1",
 		title = loc.CO_MSP,
-	});
-	tinsert(TRP3_API.register.CONFIG_STRUCTURE.elements, {
-		inherit = "TRP3_ConfigCheck",
-		title = loc.CO_MSP_T3,
-		help = loc.CO_MSP_T3_TT,
-		configKey = CONFIG_T3_ONLY,
 	});
 
 	-- Initial update

--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -31,7 +31,6 @@ local function onStart()
 	end
 
 	local Globals, Utils, Events = TRP3_API.globals, TRP3_API.utils, TRP3_API.events;
-	local getConfigValue, registerConfigKey, registerConfigHandler = TRP3_API.configuration.getValue, TRP3_API.configuration.registerConfigKey, TRP3_API.configuration.registerHandler;
 	local get, getCompleteName = TRP3_API.profile.getData, TRP3_API.register.getCompleteName;
 	local isIgnored = TRP3_API.register.isIDIgnored;
 
@@ -171,11 +170,6 @@ local function onStart()
 		updateCharacteristicsData();
 		updateAboutData();
 		updateMiscData();
-		msp:Update();
-	end
-
-	local function onAboutChanged()
-		updateAboutData();
 		msp:Update();
 	end
 
@@ -541,12 +535,6 @@ local function onStart()
 			end
 		end
 	end
-
-	-- Build configuration page
-	tinsert(TRP3_API.register.CONFIG_STRUCTURE.elements, {
-		inherit = "TRP3_ConfigH1",
-		title = loc.CO_MSP,
-	});
 
 	-- Initial update
 	updateCharacteristicsData();

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -604,8 +604,6 @@ Possible status:
 	CO_GLANCE_PRESET_TRP3_HELP = "Shortcut to setup the bar in a TRP3 style : to the bottom of the TRP3 target frame.",
 	CO_GLANCE_TT_ANCHOR = "Tooltips anchor point",
 	CO_MSP = "Mary Sue Protocol",
-	CO_MSP_T3 = "Use template 3 only",
-	CO_MSP_T3_TT = "Even if you choose another \"about\" template, the template 3 will always be used for MSP compatibility.",
 	CO_WIM = "|cffff9900Whisper channels are disabled.",
 	CO_WIM_TT = "You are using |cff00ff00WIM|r, the handling for whisper channels is disabled for compatibility purposes",
 	CO_LOCATION = "Location settings",


### PR DESCRIPTION
Wanted to check if this was a valid change before merging.

I am doubtful that anyone maintains two different versions of their About profile depending on whether or not the reader uses TRP or MSP, and in some cases the setting seems enabled with an empty T3 profile for no really good reason, causing confusion for others.