### PR TITLE
Export Psychological Traits via MSP

### DIFF
--- a/totalRP3/modules/register/main/register_exchange.lua
+++ b/totalRP3/modules/register/main/register_exchange.lua
@@ -514,8 +514,7 @@ TRP3_API.slash.registerCommand({
 		end
 
 		sendQuery(characterToOpen);
-		local request = {"TT", "HH", "AG", "AE", "HB", "DE", "HI", "AH", "AW", "MO", "NH", "IC", "CO"};
-		msp:Request(characterToOpen, request);
+		msp:Request(characterToOpen, AddOn_TotalRP3.MSP.REQUEST_FIELDS);
 		-- If we already have a profile for that user in the registry, we open it and reset the name (so it doesn't try to open again afterwards)
 		if characterToOpen == TRP3_API.globals.player_id or (isUnitIDKnown(characterToOpen) and hasProfile(characterToOpen)) then
 			TRP3_API.navigation.openMainFrame();

--- a/totalRP3/modules/register/msp/Fields.lua
+++ b/totalRP3/modules/register/msp/Fields.lua
@@ -24,6 +24,11 @@ local Globals = TRP3_API.globals;
 local module = AddOn_TotalRP3.MSP or {};
 module.log = module.log or Ellyb.Logger("MSP");
 
+-- TODO: Work on this some more. We're centralising this thing.
+module.TOOLTIP_FIELDS = {"CO", "IC", "PX", "RC", "RS", "TR"};
+module.REQUEST_FIELDS = {"TT", "AE", "AG", "AH", "AW", "CO", "DE", "HB", "HH", "HI", "IC", "MO", "NH", "MU", "PE", "PS", "RS"};
+module.REQUEST_FIELDS_MIN = {"TT", "AE", "AG", "AH", "AW", "CO", "DE", "HB", "HH", "HI", "IC", "MO", "NH"};
+
 -- Registry of known serializers/deserializers by name.
 local serializers = {};
 local deserializers = {};

--- a/totalRP3/modules/register/msp/Fields.lua
+++ b/totalRP3/modules/register/msp/Fields.lua
@@ -221,6 +221,7 @@ module.TryRegisterField("PS", {
 				if key == "id" then
 					struct.ID = tonumber(value);
 				elseif key == "value" then
+					struct.VA = math.floor(tonumber(value) * Globals.PSYCHO_MAX_VALUE_V1);
 					struct.V2 = math.floor(tonumber(value) * Globals.PSYCHO_MAX_VALUE_V2);
 				elseif key == "left-name" then
 					struct.LT = value;

--- a/totalRP3/modules/register/msp/Fields.lua
+++ b/totalRP3/modules/register/msp/Fields.lua
@@ -239,6 +239,14 @@ module.TryRegisterField("PS", {
 				end
 			end
 
+			-- Ensure we default any missing fields from custom traits.
+			if not struct.ID and (struct.LT or struct.RT) then
+				struct.LI = struct.LI or Globals.icons.default;
+				struct.LC = struct.LC or Globals.PSYCHO_DEFAULT_LEFT_COLOR:GetRGBTable();
+				struct.RI = struct.RI or Globals.icons.default;
+				struct.RC = struct.RC or Globals.PSYCHO_DEFAULT_RIGHT_COLOR:GetRGBTable();
+			end
+
 			-- If we get a trait that doesn't have either an ID or both
 			-- name fields, or is missing a value, we'll ignore it.
 			if (struct.ID or (struct.LT and struct.RT)) and struct.V2 then

--- a/totalRP3/modules/register/msp/Fields.lua
+++ b/totalRP3/modules/register/msp/Fields.lua
@@ -243,16 +243,29 @@ module.TryRegisterField("PS", {
 				end
 			end
 
-			-- Ensure we default any missing fields from custom traits.
-			if not struct.ID and (struct.LT or struct.RT) then
+			-- If it's a built-in clear any extraenous junk.
+			if struct.ID then
+				-- Capture the keepable fields and then wipe the table. Less
+				-- hassle when new things pop up.
+				local id = struct.ID;
+				local va = struct.VA;
+				local v2 = struct.V2;
+
+				table.wipe(struct);
+
+				struct.ID = id;
+				struct.VA = va;
+				struct.V2 = v2;
+			elseif struct.LT and struct.RT then
+				-- It's custom, default any missing fields.
 				struct.LI = struct.LI or Globals.icons.default;
 				struct.LC = struct.LC or Globals.PSYCHO_DEFAULT_LEFT_COLOR:GetRGBTable();
 				struct.RI = struct.RI or Globals.icons.default;
 				struct.RC = struct.RC or Globals.PSYCHO_DEFAULT_RIGHT_COLOR:GetRGBTable();
 			end
 
-			-- If we get a trait that doesn't have either an ID or both
-			-- name fields, or is missing a value, we'll ignore it.
+			-- Only register traits that are valid. If the ID or custom names
+			-- are missing, or the value isn't present we'll ignore it.
 			if (struct.ID or (struct.LT and struct.RT)) and struct.V2 then
 				table.insert(traits, struct);
 			end

--- a/totalRP3/modules/register/msp/Fields.lua
+++ b/totalRP3/modules/register/msp/Fields.lua
@@ -19,6 +19,8 @@
 
 local Ellyb = Ellyb(...);
 
+local Globals = TRP3_API.globals;
+
 local module = AddOn_TotalRP3.MSP or {};
 module.log = module.log or Ellyb.Logger("MSP");
 
@@ -145,9 +147,9 @@ module.TryRegisterField("PS", {
 
 			-- Support both old and new range values.
 			if trait.V2 then
-				table.insert(out, ([[ value="%f"]]):format(trait.V2 / 20));
+				table.insert(out, ([[ value="%f"]]):format(trait.V2 / Globals.PSYCHO_MAX_VALUE_V2));
 			elseif trait.VA then
-				table.insert(out, ([[ value="%f"]]):format(trait.VA / 6));
+				table.insert(out, ([[ value="%f"]]):format(trait.VA / Globals.PSYCHO_MAX_VALUE_V1));
 			else
 				-- Placeholder value so nothing breaks in odd circumstances.
 				table.insert(out, [[ value="0.5"]]);
@@ -219,7 +221,7 @@ module.TryRegisterField("PS", {
 				if key == "id" then
 					struct.ID = tonumber(value);
 				elseif key == "value" then
-					struct.V2 = math.floor(tonumber(value) * 20);
+					struct.V2 = math.floor(tonumber(value) * Globals.PSYCHO_MAX_VALUE_V2);
 				elseif key == "left-name" then
 					struct.LT = value;
 				elseif key == "left-icon" then

--- a/totalRP3/modules/register/msp/Fields.lua
+++ b/totalRP3/modules/register/msp/Fields.lua
@@ -1,0 +1,230 @@
+----------------------------------------------------------------------------------
+--- Total RP 3
+--- Mary Sue Protocol Field Serializers/Deserializers
+--- ---------------------------------------------------------------------------
+--- Copyright 2019 Daniel "Meorawr" Yates <me@meorawr.io>
+---
+--- Licensed under the Apache License, Version 2.0 (the "License");
+--- you may not use this file except in compliance with the License.
+--- You may obtain a copy of the License at
+---
+--- 	http://www.apache.org/licenses/LICENSE-2.0
+---
+--- Unless required by applicable law or agreed to in writing, software
+--- distributed under the License is distributed on an "AS IS" BASIS,
+--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--- See the License for the specific language governing permissions and
+--- limitations under the License.
+----------------------------------------------------------------------------------
+
+local Ellyb = Ellyb(...);
+
+local module = AddOn_TotalRP3.MSP or {};
+module.log = module.log or Ellyb.Logger("MSP");
+
+local serializers = {};
+local deserializers = {};
+
+function module.SerializeField(field, ...)
+	Ellyb.Assertions.isNotNil(field, "field");
+
+	local serializer = serializers[field];
+	if not serializer then
+		return nil;
+	end
+
+	local ok, result = pcall(serializer, ...);
+	if not ok then
+		local err = result or "<nil error>";
+		module.log:Severe(("Error serializing field %q: %s"):format(field, err));
+		return nil;
+	end
+
+	return result;
+end
+
+function module.DeserializeField(field, value)
+	Ellyb.Assertions.isNotNil(field, "field");
+
+	local deserializer = deserializers[field];
+	if not deserializer then
+		return nil;
+	end
+
+	local ok, result = pcall(deserializer, value);
+	if not ok then
+		local err = result or "<nil error>";
+		module.log:Severe(("Error deserializing field %q: %s"):format(field, err));
+		return nil;
+	end
+
+	return result;
+end
+
+function module.RegisterField(field, spec)
+	Ellyb.Assertions.isNotNil(field, "field");
+	Ellyb.Assertions.isType(spec, "table", "spec");
+
+	-- Check the required fields in the spec table and assert their existence.
+	Ellyb.Assertions.isNotNil(spec.Serialize, "spec.Serialize");
+	Ellyb.Assertions.isNotNil(spec.Deserialize, "spec.Deserialize");
+
+	-- Verify the field doesn't already exist.
+	if serializers[field] or deserializers[field] then
+		error(("Field %q has already been registered"):format(field), 2);
+	end
+
+	serializers[field] = spec.Serialize;
+	deserializers[field] = spec.Deserialize;
+end
+
+function module.TryRegisterField(...)
+	if not pcall(module.RegisterField, ...) then
+		return false;
+	end
+
+	return true
+end
+
+AddOn_TotalRP3.MSP = module;
+
+---
+--- Serializer/Deserializer Implementations
+---
+
+-- The PS field is serialized to the form:
+--    attr  := ident "=" quoted-value
+--    trait := "[trait" { " " attr } "]"
+--
+-- Where `ident` is just an ASCII string identifier like "name" or "icon"
+-- with support for limited special characters (-, _), and `quoted-value` is
+-- a value wrapped in double quotes.
+--
+-- For now, there's no support for escaping " characters in quoted-values`.
+--
+-- Example:
+--    [trait id="3" value="0.75"]
+--    [trait value="0.4" left-name="My Left Trait" right-name="My Right Trait"]
+--
+-- A newline may be present between individual trait pairs but isn't required.
+--
+-- In terms of attributes, the following are supported:
+--    id:    Numeric identifier for a standard trait.
+--    value: [0-1] floating point number representing the strength of this trait.
+--    (left|right)-name:  Name of a custom trait.
+--    (left|right)-icon:  Name of a custom icon for this trait.
+--    (left|right)-color: Hexadecimal color code for this trait.
+
+module.TryRegisterField("PS", {
+	Serialize = function(traits)
+		local out = Ellyb.Tables.getTempTable();
+		for traitIndex = 1, #traits do
+			-- Start writing out this trait.
+			local trait = traits[traitIndex];
+			table.insert(out, "[trait");
+
+			-- Support both old and new range values.
+			if trait.V2 then
+				table.insert(out, ([[ value="%f"]]):format(trait.V2 / 20));
+			elseif trait.VA then
+				table.insert(out, ([[ value="%f"]]):format(trait.VA / 6));
+			else
+				-- Placeholder value so nothing breaks in odd circumstances.
+				table.insert(out, [[ value="0.5"]]);
+			end
+
+			-- If there's an ID it's a built-in trait, otherwise it's custom
+			-- and thus needs the name/icon/color stuff.
+			if trait.ID then
+				table.insert(out, ([[ id="%d"]]):format(trait.ID));
+			else
+				-- We'll strip " from the name for simplicity if present.
+				local leftName = (trait.LT or ""):gsub([["]], "");
+				local leftIcon = trait.LI or "";
+
+				table.insert(out, ([[ left-name=%q]]):format(leftName));
+				table.insert(out, ([[ left-icon=%q]]):format(leftIcon));
+				table.insert(out, ([[ left-color="%02x%02x%02x"]]):format(
+					(trait.LC.r or 1) * 255,
+					(trait.LC.g or 1) * 255,
+					(trait.LC.b or 1) * 255
+				));
+
+				local rightName = (trait.RT or ""):gsub([["]], "");
+				local rightIcon = trait.RI or "";
+
+				table.insert(out, ([[ right-name=%q]]):format(rightName));
+				table.insert(out, ([[ right-icon=%q]]):format(rightIcon));
+				table.insert(out, ([[ right-color="%02x%02x%02x"]]):format(
+					(trait.RC.r or 1) * 255,
+					(trait.RC.g or 1) * 255,
+					(trait.RC.b or 1) * 255
+				));
+			end
+
+			-- Close off the trait line and concat the contents.
+			table.insert(out, "]");
+			out[traitIndex] = table.concat(out, "", traitIndex);
+
+			-- Remove the pieces from the table in reverse order. The idea
+			-- is that out[traitIndex] is our full trait string and everything
+			-- afterwards is nil.
+			for i = #out, traitIndex + 1, -1 do
+				out[i] = nil;
+			end
+		end
+
+		-- Join all the resulting traits into a single string.
+		local traitString = table.concat(out, "");
+		Ellyb.Tables.releaseTempTable(out);
+
+		module.DeserializeField("PS", traitString);
+		return traitString;
+	end,
+
+	Deserialize = function(value)
+		-- Shortcut cases where a profile hasn't given us a thing.
+		if not value or type(value) ~= "string" then
+			return nil;
+		end
+
+		-- We'll store the resulting trait structures here.
+		local traits = {};
+
+		-- Parse each [trait {attr...}] block.
+		for trait in value:gmatch("%[trait [^%]]-%]") do
+			local struct = {};
+
+			-- And then each attr="value" pair.
+			for key, value in trait:gmatch("([%w_-]+)=\"([^\"]*)\"") do
+				if key == "id" then
+					struct.ID = tonumber(value);
+				elseif key == "value" then
+					struct.V2 = math.floor(tonumber(value) * 20);
+				elseif key == "left-name" then
+					struct.LT = value;
+				elseif key == "left-icon" then
+					struct.LI = value;
+				elseif key == "left-color" then
+					local r, g, b = Ellyb.ColorManager.hexaToNumber(value);
+					struct.LC = { r = r, g = g, b = b };
+				elseif key == "right-name" then
+					struct.RT = value;
+				elseif key == "right-icon" then
+					struct.RI = value;
+				elseif key == "right-color" then
+					local r, g, b = Ellyb.ColorManager.hexaToNumber(value);
+					struct.RC = { r = r, g = g, b = b };
+				end
+			end
+
+			-- If we get a trait that doesn't have either an ID or both
+			-- name fields, or is missing a value, we'll ignore it.
+			if (struct.ID or (struct.LT and struct.RT)) and struct.V2 then
+				table.insert(traits, struct);
+			end
+		end
+
+		return traits;
+	end,
+});

--- a/totalRP3/modules/register/msp/Fields.lua
+++ b/totalRP3/modules/register/msp/Fields.lua
@@ -198,7 +198,6 @@ module.TryRegisterField("PS", {
 		local traitString = table.concat(out, "");
 		Ellyb.Tables.releaseTempTable(out);
 
-		module.DeserializeField("PS", traitString);
 		return traitString;
 	end,
 

--- a/totalRP3/modules/register/msp/Fields.lua
+++ b/totalRP3/modules/register/msp/Fields.lua
@@ -22,9 +22,15 @@ local Ellyb = Ellyb(...);
 local module = AddOn_TotalRP3.MSP or {};
 module.log = module.log or Ellyb.Logger("MSP");
 
+-- Registry of known serializers/deserializers by name.
 local serializers = {};
 local deserializers = {};
 
+-- SerializeField converts a given TRP profile value back to an
+-- MSP-exportable value (typically a string or number).
+--
+-- If the serializer for the named field encounters an error, it is logged
+-- and nil is returned instead.
 function module.SerializeField(field, ...)
 	Ellyb.Assertions.isNotNil(field, "field");
 
@@ -43,6 +49,11 @@ function module.SerializeField(field, ...)
 	return result;
 end
 
+-- DeserializeField converts a given field value back to a TRP-compatible
+-- result for storage in a profile.
+--
+-- If the deserializer for the named field encounters an error, it is logged
+-- and nil is returned instead.
 function module.DeserializeField(field, value)
 	Ellyb.Assertions.isNotNil(field, "field");
 
@@ -61,6 +72,13 @@ function module.DeserializeField(field, value)
 	return result;
 end
 
+-- Registers a field with the given name and specification. The specification
+-- must contain two functions with the keys Serialize and Deserialize.
+--
+-- If the field already exists, an error is raised.
+--
+-- @param field string The name of the field to add.
+-- @param spec  table  The specification for this field.
 function module.RegisterField(field, spec)
 	Ellyb.Assertions.isNotNil(field, "field");
 	Ellyb.Assertions.isType(spec, "table", "spec");
@@ -78,6 +96,8 @@ function module.RegisterField(field, spec)
 	deserializers[field] = spec.Deserialize;
 end
 
+-- Attempts to register a named field with the given specification. If the
+-- field already exists, false is returned, else true.
 function module.TryRegisterField(...)
 	if not pcall(module.RegisterField, ...) then
 		return false;

--- a/totalRP3/modules/register/msp/Fields.lua
+++ b/totalRP3/modules/register/msp/Fields.lua
@@ -160,8 +160,8 @@ module.TryRegisterField("PS", {
 			if trait.ID then
 				table.insert(out, ([[ id="%d"]]):format(trait.ID));
 			else
-				-- We'll strip " from the name for simplicity if present.
-				local leftName = (trait.LT or ""):gsub([["]], "");
+				-- We'll strip " and ] from the name for simplicity if present.
+				local leftName = (trait.LT or ""):gsub("[%]=]", "");
 				local leftIcon = trait.LI or "";
 
 				table.insert(out, ([[ left-name=%q]]):format(leftName));
@@ -172,7 +172,7 @@ module.TryRegisterField("PS", {
 					(trait.LC.b or 1) * 255
 				));
 
-				local rightName = (trait.RT or ""):gsub([["]], "");
+				local rightName = (trait.RT or ""):gsub("[%]=]", "");
 				local rightIcon = trait.RI or "";
 
 				table.insert(out, ([[ right-name=%q]]):format(rightName));

--- a/totalRP3/modules/register/msp/Fields.lua
+++ b/totalRP3/modules/register/msp/Fields.lua
@@ -202,9 +202,9 @@ module.TryRegisterField("PS", {
 		return traitString;
 	end,
 
-	Deserialize = function(value)
+	Deserialize = function(fieldValue)
 		-- Shortcut cases where a profile hasn't given us a thing.
-		if not value or type(value) ~= "string" then
+		if not fieldValue or type(fieldValue) ~= "string" then
 			return nil;
 		end
 
@@ -212,7 +212,7 @@ module.TryRegisterField("PS", {
 		local traits = {};
 
 		-- Parse each [trait {attr...}] block.
-		for trait in value:gmatch("%[trait [^%]]-%]") do
+		for trait in fieldValue:gmatch("%[trait [^%]]-%]") do
 			local struct = {};
 
 			-- And then each attr="value" pair.

--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -38,7 +38,7 @@ local function onStart()
 	-- LibMSP support code
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	msp_RPAddOn = "Total RP 3";
-	msp:AddFieldsToTooltip({'PX', 'RC', 'IC', 'CO', 'TR', 'RS'});
+	msp:AddFieldsToTooltip(AddOn_TotalRP3.MSP.TOOLTIP_FIELDS);
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 	-- Update
@@ -505,8 +505,6 @@ local function onStart()
 		end
 	end);
 
-	local REQUEST_TAB = {"TT", "PE", "HH", "AG", "AE", "HB", "AH", "AW", "MO", "DE", "HI", "MU", "RS", "PS"};
-
 	local function requestInformation(targetID, targetMode)
 		if not targetID then return end
 		local data = msp.char[targetID].field;
@@ -515,14 +513,14 @@ local function onStart()
 		and not isIgnored(targetID)
 		and data.VA:sub(1, 8) ~= "TotalRP3"
 		then
-			msp:Request(targetID, REQUEST_TAB);
+			msp:Request(targetID, AddOn_TotalRP3.MSP.REQUEST_FIELDS);
 		end
 	end
 
 	TRP3_API.r.sendMSPQuery = function(name)
 		-- This function has never had the checks that the above does. Whether
 		-- it should or not should be revisited in the future.
-		msp:Request(name, REQUEST_TAB);
+		msp:Request(name, AddOn_TotalRP3.MSP.REQUEST_FIELDS);
 	end
 
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*

--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -338,7 +338,7 @@ local function onStart()
 						end
 						-- Machine-formatted psychological traits.
 						if field == "PS" and value then
-							profile.characteristics[CHARACTERISTICS_FIELDS[field]] = AddOn_TotalRP3.MRP.DeserializeField(field, value);
+							profile.characteristics[CHARACTERISTICS_FIELDS[field]] = AddOn_TotalRP3.MSP.DeserializeField(field, value);
 						end
 					elseif ABOUT_FIELDS[field] then
 						if field == "MU" then

--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -139,6 +139,8 @@ local function onStart()
 				end
 			end
 		end
+
+		msp.my['PS'] = AddOn_TotalRP3.MSP.SerializeField("PS", dataTab.PS);
 	end
 
 	local function updateMiscData()
@@ -192,7 +194,7 @@ local function onStart()
 	local SUPPORTED_FIELDS = {
 		"VA", "NA", "NH", "NI", "NT", "RA", "CU", "FR", "FC", "PX", "RC",
 		"IC", "CO", "PE", "HH", "AG", "AE", "HB", "AH", "AW", "MO", "DE",
-		"HI", "TR", "MU", "RS"
+		"HI", "TR", "MU", "RS", "PS"
 	};
 
 	local CHARACTERISTICS_FIELDS = {
@@ -209,6 +211,7 @@ local function onStart()
 		PX = "TI",
 		IC = "IC",
 		RS = "RS",
+		PS = "PS",
 	}
 
 	local CHARACTER_FIELDS = {
@@ -332,6 +335,10 @@ local function onStart()
 						-- Hack for spaced name tolerated in MRP
 						if field == "NA" and not profile.characteristics[CHARACTERISTICS_FIELDS[field]] then
 							profile.characteristics[CHARACTERISTICS_FIELDS[field]] = unitIDToInfo(senderID);
+						end
+						-- Machine-formatted psychological traits.
+						if field == "PS" and value then
+							profile.characteristics[CHARACTERISTICS_FIELDS[field]] = AddOn_TotalRP3.MRP.DeserializeField(field, value);
 						end
 					elseif ABOUT_FIELDS[field] then
 						if field == "MU" then
@@ -498,7 +505,7 @@ local function onStart()
 		end
 	end);
 
-	local REQUEST_TAB = {"TT", "PE", "HH", "AG", "AE", "HB", "AH", "AW", "MO", "DE", "HI", "MU", "RS"};
+	local REQUEST_TAB = {"TT", "PE", "HH", "AG", "AE", "HB", "AH", "AW", "MO", "DE", "HI", "MU", "RS", "PS"};
 
 	local function requestInformation(targetID, targetMode)
 		if not targetID then return end

--- a/totalRP3/modules/register/register_includes.xml
+++ b/totalRP3/modules/register/register_includes.xml
@@ -25,7 +25,7 @@
 	<Include file="main\register_ui_glance.xml" />
 	<Include file="main\register_ui_list.xml" />
 	<Include file="characters\register_ui_main.xml" />
-	
+
 	<Script file="characters\register_main.lua" />
 	<Script file="characters\register_ignore.lua" />
 	<Script file="characters\register_characteristics.lua" />
@@ -33,9 +33,9 @@
 	<Script file="characters\register_misc.lua" />
 
 	<Include file="characters\PlayerMapScan\PlayerMapScan.xml" />
-	
+
 	<Include file="companions\register_ui_companions_main.xml" />
-	
+
 	<Script file="main\register_exchange.lua" />
 	<Script file="main\register_tooltip.lua" />
 	<Script file="main\register_list.lua" />
@@ -45,7 +45,8 @@
 
 	<Script file="characters\register_score.lua" />
 	<Script file="main\register_glance.lua" />
-	
+
+	<Script file="msp\Fields.lua" />
 	<Script file="msp\register_msp.lua" />
 
 	<Frame name="TRP3_CursorFrame" parent="UIParent" hidden="true">


### PR DESCRIPTION
Purpose of this field is to allow her to add in some pretty displays for traits on MRP's end. While we do have that psychological section in template 3 present, I don't think it's reasonable for us to ever come up with a human-readable text format for traits that remains extensible, especially given the features available to custom traits.

As it's a new field I designed it around the limitation that it'd be machine-readable, but it's also somewhat debuggable by having a rather simple `[trait key="value" key2="value2"]` format.

Additionally I took the opportunity to try and make MSP fields testable by adding a basic framework for registering/serializing/deserializing them. I didn't really want to add another ~100 lines to the middle of the existing MSP code to further confuse things there.

A few things need to be resolved:

1. Kat needs to implement her end of things :)
2. We need to decide on a mapping of ID numbers for the "built-in" or "standard" traits (like Lustful/Chaste). Could use TRPs ID numbers but a better idea might come along (string IDs? Easier to recognise but longer to send).
3. The `key="value"` pairs at the moment need `]` and `"` characters stripped from the values. Current impl does the latter only because I forgot about the square brackets. Adding support for escaping quotes would be a lot of work on the reading end, so I'm against that - and it's not like anyone is really going to use them in a trait.
4. More protection is needed when receiving a trait that has no icon/color information possibly.
5. If there's no color/icon/custom name/ID field we might send some weird stuff out. Should probably protect against that somehow.