### PR TITLE
Fix long special char lines in T3 profiles

### DIFF
--- a/totalRP3/modules/register/characters/register_ui_about.xml
+++ b/totalRP3/modules/register/characters/register_ui_about.xml
@@ -437,7 +437,7 @@
 																<Anchor point="RIGHT" x="0" y="0"/>
 															</Anchors>
 														</FontString>
-														<FontString name="TRP3_RegisterAbout_AboutPanel_Template3_1_Text" text="[Title]" inherits="GameFontNormal" justifyH="LEFT" justifyV="TOP">
+														<FontString name="TRP3_RegisterAbout_AboutPanel_Template3_1_Text" text="[Title]" inherits="GameFontNormal" justifyH="LEFT" justifyV="TOP" nonSpaceWrap="true">
 															<Anchors>
 																<Anchor point="TOP" x="0" y="-5" relativePoint="BOTTOM" relativeTo="TRP3_RegisterAbout_AboutPanel_Template3_1_Title"/>
 															</Anchors>
@@ -463,7 +463,7 @@
 																<Anchor point="RIGHT" x="0" y="0"/>
 															</Anchors>
 														</FontString>
-														<FontString name="TRP3_RegisterAbout_AboutPanel_Template3_2_Text" text="[Title]" inherits="GameFontNormal" justifyH="LEFT" justifyV="TOP">
+														<FontString name="TRP3_RegisterAbout_AboutPanel_Template3_2_Text" text="[Title]" inherits="GameFontNormal" justifyH="LEFT" justifyV="TOP" nonSpaceWrap="true">
 															<Anchors>
 																<Anchor point="TOP" x="0" y="-5" relativePoint="BOTTOM" relativeTo="TRP3_RegisterAbout_AboutPanel_Template3_2_Title"/>
 															</Anchors>
@@ -489,7 +489,7 @@
 																<Anchor point="RIGHT" x="0" y="0"/>
 															</Anchors>
 														</FontString>
-														<FontString name="TRP3_RegisterAbout_AboutPanel_Template3_3_Text" text="[Title]" inherits="GameFontNormal" justifyH="LEFT" justifyV="TOP">
+														<FontString name="TRP3_RegisterAbout_AboutPanel_Template3_3_Text" text="[Title]" inherits="GameFontNormal" justifyH="LEFT" justifyV="TOP" nonSpaceWrap="true">
 															<Anchors>
 																<Anchor point="TOP" x="0" y="-5" relativePoint="BOTTOM" relativeTo="TRP3_RegisterAbout_AboutPanel_Template3_3_Title"/>
 															</Anchors>


### PR DESCRIPTION
Some people like to draw fancy boxes but there's a weird bug that I'm tempted to blame Blizzard for, however we trigger it by not having set the NonSpaceWrap flag set on our fontstring views.

(Also as to why this took two damn force pushes, well the PR didn't want to be flagged as auto-mergeable.)