### PR TITLE
Correctly clear msp.char on registry deletion

### DIFF
--- a/totalRP3/modules/register/characters/register_main.lua
+++ b/totalRP3/modules/register/characters/register_main.lua
@@ -99,15 +99,23 @@ local function deleteProfile(profileID, dontFireEvents)
 			end
 		end
 	end
+
+	-- Deleting a profile should clear the local MSP knowledge of it,
+	-- otherwise things get out of sync if the profile comes through again
+	-- after deletion. For compatibility we'll still emit the table of owners.
 	local mspOwners;
-	if not dontFireEvents then
-		if profiles[profileID].msp then
-			mspOwners = {};
-			for ownerID, _ in pairs(profiles[profileID].link) do
+	if profiles[profileID].msp then
+		for ownerID, _ in pairs(profiles[profileID].link) do
+			msp.char[ownerID] = nil;
+
+			-- No need to build the owner table if we ain't gonna emit it.
+			if not dontFireEvents then
+				mspOwners = mspOwners or {};
 				tinsert(mspOwners, ownerID);
 			end
 		end
 	end
+
 	wipe(profiles[profileID]);
 	profiles[profileID] = nil;
 	if not dontFireEvents then

--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -553,13 +553,6 @@ local function onStart()
 			end
 		end
 	end);
-	Events.listenToEvent(Events.REGISTER_PROFILE_DELETED, function(_, mspOwners)
-		if mspOwners then
-			for _, ownerID in pairs(mspOwners) do
-				msp.char[ownerID] = nil;
-			end
-		end
-	end);
 	Events.listenToEvent(Events.MOUSE_OVER_CHANGED, requestInformation);
 
 end


### PR DESCRIPTION
deleteProfile was being called in such a way that it would never emit an event with the mspOwners table populated, thus the handler in the MSP module would never clear msp.chars for any deleted profiles.

This would mean that profiles which are culled then re-received in the same UI session would be horribly desynced; the MSP module would see the data in msp.chars and think it was up to date but the TRP data would have very few fields present.

I imagine there's a solid reason behind _why_ deletion doesn't propagate events, including but not limited to the potential of an infinite loop, so instead we've decided to just delete the msp.chars entries directly from within deleteProfile. The table of mspOwners will still be emitted if it can, but the data won't be present in msp.chars at the time of emission. This shouldn't be a concern because event handler order is (hopefully) unspecified.