### PR TITLE
Don't use localized section headers in DE field

### DIFF
--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -80,7 +80,7 @@ local function onStart()
 			msp.my['HI'] = removeTextTags(dataTab.T3.HI.TX);
 			local PH = removeTextTags(dataTab.T3.PH.TX) or "";
 			local PS = removeTextTags(dataTab.T3.PS.TX) or "";
-			msp.my['DE'] = ("#%s\n\n%s\n\n---\n\n#%s\n\n%s"):format(loc.REG_PLAYER_PHYSICAL, PH, loc.REG_PLAYER_PSYCHO, PS);
+			msp.my['DE'] = ("#Physical Description\n\n%s\n\n---\n\n#Personality traits\n\n%s"):format(PH, PS);
 		elseif dataTab.TE == 1 then
 			msp.my['DE'] = removeTextTags(dataTab.T1.TX);
 		elseif dataTab.TE == 2 then


### PR DESCRIPTION
Other addons rely on these being in plain English so they can operate on them for changing how they get displayed on their end.

This PR is brought to you by Katorie. She screamed.