### PR TITLE
Send formatting tags via MSP DE field

### DIFF
--- a/totalRP3/modules/register/msp/register_msp.lua
+++ b/totalRP3/modules/register/msp/register_msp.lua
@@ -66,8 +66,7 @@ local function onStart()
 	local function removeTextTags(text)
 		if text then
 			text = Utils.str.convertTextTags(text);
-			text = text:gsub("%{link%*(.-)%*(.-)%}","[%2]( %1 )"); --cleanup links instead of outright removing the tag
-			return text:gsub("%{.-%}", "");
+			return text:gsub("%{link%*(.-)%*(.-)%}","[%2]( %1 )"); --cleanup links instead of outright removing the tag
 		end
 	end
 


### PR DESCRIPTION
Allows sending of formatting tags like {p} and {h1} via MSP, which enables MRP to support them in its upcoming browser rework.

Other addons will need to strip them on receipt; we'll have a library to centralize this eventually, but for now this delivers the requirement. Other addons represent an extremely minimal segment of the userbase anyway (if they even work...).