### PR TITLE
1.6.0 fixes before release

### DIFF
--- a/totalRP3/core/impl/ui_tools.lua
+++ b/totalRP3/core/impl/ui_tools.lua
@@ -935,33 +935,39 @@ function TRP3_API.ui.text.setupToolbar(toolbar, textFrame, parentFrame, point, p
 	toolbar.h2.tagIndex = 2;
 	toolbar.h3.tagIndex = 3;
 	toolbar.p.tagIndex = 4;
-	toolbar.h1:SetScript("OnClick", function(button) onContainerTagClicked(button, toolbar.textFrame) end);
-	toolbar.h2:SetScript("OnClick", function(button) onContainerTagClicked(button, toolbar.textFrame) end);
-	toolbar.h3:SetScript("OnClick", function(button) onContainerTagClicked(button, toolbar.textFrame) end);
-	toolbar.p:SetScript("OnClick", function(button) onContainerTagClicked(button, toolbar.textFrame, true) end);
+	toolbar.h1:SetScript("OnClick", function(button) if toolbar.textFrame then onContainerTagClicked(button, toolbar.textFrame) end end);
+	toolbar.h2:SetScript("OnClick", function(button) if toolbar.textFrame then onContainerTagClicked(button, toolbar.textFrame) end end);
+	toolbar.h3:SetScript("OnClick", function(button) if toolbar.textFrame then onContainerTagClicked(button, toolbar.textFrame) end end);
+	toolbar.p:SetScript("OnClick", function(button) if toolbar.textFrame then onContainerTagClicked(button, toolbar.textFrame, true) end end);
 	toolbar.icon:SetScript("OnClick", function()
-		TRP3_API.popup.showPopup(
-			TRP3_API.popup.ICONS,
-			{parent = parentFrame, point = point, parentPoint = parentPoint},
-			{function(icon) onIconTagSelected(icon, toolbar.textFrame) end});
+		if toolbar.textFrame then 
+			TRP3_API.popup.showPopup(
+				TRP3_API.popup.ICONS,
+				{parent = parentFrame, point = point, parentPoint = parentPoint},
+				{function(icon) onIconTagSelected(icon, toolbar.textFrame) end});
+		end
 	end);
 	toolbar.color:SetScript("OnClick", function()
-		if shiftDown() or (getConfigValue and getConfigValue("default_color_picker")) then
-			TRP3_API.popup.showDefaultColorPicker({function(red, green, blue) onColorTagSelected(red, green, blue, toolbar.textFrame) end});
-		else
-			TRP3_API.popup.showPopup(
-				TRP3_API.popup.COLORS,
-				{parent = parentFrame, point = point, parentPoint = parentPoint},
-				{function(red, green, blue) onColorTagSelected(red, green, blue, toolbar.textFrame) end});
+		if toolbar.textFrame then 
+			if shiftDown() or (getConfigValue and getConfigValue("default_color_picker")) then
+				TRP3_API.popup.showDefaultColorPicker({function(red, green, blue) onColorTagSelected(red, green, blue, toolbar.textFrame) end});
+			else
+				TRP3_API.popup.showPopup(
+					TRP3_API.popup.COLORS,
+					{parent = parentFrame, point = point, parentPoint = parentPoint},
+					{function(red, green, blue) onColorTagSelected(red, green, blue, toolbar.textFrame) end});
+			end
 		end
 	end);
 	toolbar.image:SetScript("OnClick", function()
-		TRP3_API.popup.showPopup(
-			TRP3_API.popup.IMAGES,
-			{parent = parentFrame, point = point, parentPoint = parentPoint},
-			{function(image) onImageTagSelected(image, toolbar.textFrame) end});
+		if toolbar.textFrame then 
+			TRP3_API.popup.showPopup(
+				TRP3_API.popup.IMAGES,
+				{parent = parentFrame, point = point, parentPoint = parentPoint},
+				{function(image) onImageTagSelected(image, toolbar.textFrame) end});
+		end
 	end);
-	toolbar.link:SetScript("OnClick", function() onLinkTagClicked(toolbar.textFrame) end);
+	toolbar.link:SetScript("OnClick", function() if toolbar.textFrame then onLinkTagClicked(toolbar.textFrame) end end);
 end
 
 function TRP3_API.ui.text.changeToolbarTextFrame(toolbar, textFrame)

--- a/totalRP3/core/impl/ui_tools.lua
+++ b/totalRP3/core/impl/ui_tools.lua
@@ -940,7 +940,7 @@ function TRP3_API.ui.text.setupToolbar(toolbar, textFrame, parentFrame, point, p
 	toolbar.h3:SetScript("OnClick", function(button) if toolbar.textFrame then onContainerTagClicked(button, toolbar.textFrame) end end);
 	toolbar.p:SetScript("OnClick", function(button) if toolbar.textFrame then onContainerTagClicked(button, toolbar.textFrame, true) end end);
 	toolbar.icon:SetScript("OnClick", function()
-		if toolbar.textFrame then 
+		if toolbar.textFrame then
 			TRP3_API.popup.showPopup(
 				TRP3_API.popup.ICONS,
 				{parent = parentFrame, point = point, parentPoint = parentPoint},
@@ -948,7 +948,7 @@ function TRP3_API.ui.text.setupToolbar(toolbar, textFrame, parentFrame, point, p
 		end
 	end);
 	toolbar.color:SetScript("OnClick", function()
-		if toolbar.textFrame then 
+		if toolbar.textFrame then
 			if shiftDown() or (getConfigValue and getConfigValue("default_color_picker")) then
 				TRP3_API.popup.showDefaultColorPicker({function(red, green, blue) onColorTagSelected(red, green, blue, toolbar.textFrame) end});
 			else
@@ -960,7 +960,7 @@ function TRP3_API.ui.text.setupToolbar(toolbar, textFrame, parentFrame, point, p
 		end
 	end);
 	toolbar.image:SetScript("OnClick", function()
-		if toolbar.textFrame then 
+		if toolbar.textFrame then
 			TRP3_API.popup.showPopup(
 				TRP3_API.popup.IMAGES,
 				{parent = parentFrame, point = point, parentPoint = parentPoint},

--- a/totalRP3/modules/register/characters/ReportProfileButton.lua
+++ b/totalRP3/modules/register/characters/ReportProfileButton.lua
@@ -40,32 +40,14 @@ TRP3_API.Events.registerCallback(TRP3_API.Events.WORKFLOW_ON_LOADED, function()
         onClick = function()
             local DATE_FORMAT = "%Y-%m-%d around %H:%M";
             local playerID = TRP3_API.utils.str.getUnitID("target");
-			local player = AddOn_TotalRP3.Player.CreateFromCharacterID(playerID);
             local profile = TRP3_API.register.getUnitIDProfile(playerID)
-            local characterInfo = TRP3_API.register.getUnitIDCharacter(playerID);
 
-            assert(profile, "Something went wrong, could not retrieve the profile.")
-            assert(characterInfo, "Something went wrong, could not retrieve the information about the player linked to this profile.")
-            assert(profile.link and Ellyb.Tables.size(profile.link) > 0, "Something went wrong, could not retrieve the players linked to this profile.")
-
-            local playerLocation = PlayerLocation:CreateFromUnit("target");
-
-            slightlyCustomizeReportingFrame()
-            PlayerReportFrame:InitiateReport(PLAYER_REPORT_TYPE_LANGUAGE, playerID, playerLocation);
-
-            -- Use reporting template
-            local commentText = loc.REG_REPORT_PLAYER_TEMPLATE:format(characterInfo.client);
-
-            -- Add information about the last time we saw this profile, if we have the info
+            local reportText = loc.REG_REPORT_PLAYER_OPEN_URL_160:format(playerID);
             if profile.time then
-                commentText = commentText .. "\n" .. loc.REG_REPORT_PLAYER_TEMPLATE_DATE:format(date(DATE_FORMAT, profile.time));
+                local DATE_FORMAT = "%Y-%m-%d around %H:%M";
+                reportText = reportText .. "\n\n" .. loc.REG_REPORT_PLAYER_TEMPLATE_DATE:format(date(DATE_FORMAT, profile.time));
             end
-
-            -- Indicate if this was a trial account if we have that info
-            if player:IsOnATrialAccount() then
-                commentText = commentText .. "\n" .. loc.REG_REPORT_PLAYER_TEMPLATE_TRIAL_ACCOUNT;
-            end
-            PlayerReportFrame.CommentBox:SetText(commentText);
+            Ellyb.Popups:OpenURL("https://battle.net/support/help/product/wow/197/1501/solution", reportText);
         end,
         tooltip =  REPORT_ICON:GenerateString(25) .. loc.REG_REPORT_PLAYER_PROFILE,
         tooltipSub = loc.REG_REPORT_PLAYER_PROFILE_TT,

--- a/totalRP3/modules/register/characters/ReportProfileButton.lua
+++ b/totalRP3/modules/register/characters/ReportProfileButton.lua
@@ -21,12 +21,6 @@ local Ellyb = Ellyb(...);
 
 local loc = TRP3_API.loc;
 
-local function slightlyCustomizeReportingFrame()
-    PlayerReportFrame:SetHeight(254)
-    PlayerReportFrame.Comment:SetHeight(120)
-    PlayerReportFrame.CommentBox:SetMaxLetters(250);
-end
-
 local REPORT_ICON = Ellyb.Icon([[Interface\HelpFrame\HelpIcon-OpenTicket]]);
 
 TRP3_API.Events.registerCallback(TRP3_API.Events.WORKFLOW_ON_LOADED, function()
@@ -38,7 +32,6 @@ TRP3_API.Events.registerCallback(TRP3_API.Events.WORKFLOW_ON_LOADED, function()
             return UnitIsPlayer("target") and unitID ~= TRP3_API.globals.player_id
         end,
         onClick = function()
-            local DATE_FORMAT = "%Y-%m-%d around %H:%M";
             local playerID = TRP3_API.utils.str.getUnitID("target");
             local profile = TRP3_API.register.getUnitIDProfile(playerID)
 

--- a/totalRP3/modules/register/characters/register_main.lua
+++ b/totalRP3/modules/register/characters/register_main.lua
@@ -779,7 +779,12 @@ function TRP3_API.register.init()
 	TRP3_ProfileReportButton:SetScript("OnClick", function()
 		local context = TRP3_API.navigation.page.getCurrentContext();
 		local characterID = getFirstCharacterIDFromProfile(context.profile) or UNKNOWN;
-		Ellyb.Popups:OpenURL("https://battle.net/support/help/product/wow/197/1501/solution", loc.REG_REPORT_PLAYER_OPEN_URL:format(characterID));
+		local reportText = loc.REG_REPORT_PLAYER_OPEN_URL_160:format(characterID);
+		if context.profile.time then
+			local DATE_FORMAT = "%Y-%m-%d around %H:%M";
+			reportText = reportText .. "\n\n" .. loc.REG_REPORT_PLAYER_TEMPLATE_DATE:format(date(DATE_FORMAT, context.profile.time));
+		end
+		Ellyb.Popups:OpenURL("https://battle.net/support/help/product/wow/197/1501/solution", reportText);
 	end)
 
 	Ellyb.Tooltips.getTooltip(TRP3_ProfileReportButton):SetTitle(loc.REG_REPORT_PLAYER_PROFILE)

--- a/totalRP3/modules/register/characters/register_main.lua
+++ b/totalRP3/modules/register/characters/register_main.lua
@@ -472,7 +472,7 @@ end
 
 local function createTabBar()
 	local frame = CreateFrame("Frame", "TRP3_RegisterMainTabBar", TRP3_RegisterMain);
-	frame:SetSize(500, 30);
+	frame:SetSize(485, 30);
 	frame:SetPoint("TOPLEFT", 17, 0);
 	frame:SetFrameLevel(1);
 	tabGroup = TRP3_API.ui.frame.createTabPanel(frame,
@@ -480,7 +480,7 @@ local function createTabBar()
 			{ loc.REG_PLAYER_CARACT, 1, 150 },
 			{ loc.REG_PLAYER_ABOUT, 2, 110 },
 			{ loc.REG_PLAYER_PEEK, 3, 130 },
-			{ loc.REG_PLAYER_NOTES, 4, 100 }
+			{ loc.REG_PLAYER_NOTES, 4, 85 }
 		},
 		function(_, value)
 			-- Clear all

--- a/totalRP3/modules/register/main/register_list.lua
+++ b/totalRP3/modules/register/main/register_list.lua
@@ -368,12 +368,13 @@ local function getCharacterLines()
 	local nameSearch = TRP3_RegisterListFilterCharactName:GetText():lower();
 	local guildSearch = TRP3_RegisterListFilterCharactGuild:GetText():lower();
 	local realmOnly = TRP3_RegisterListFilterCharactRealm:GetChecked();
+	local notesOnly = TRP3_RegisterListFilterCharactNotes:GetChecked();
 	local profileList = getProfileList();
 	local fullSize = tsize(profileList);
 	wipe(characterLines);
 
 	for profileID, profile in pairs(profileList) do
-		local nameIsConform, guildIsConform, realmIsConform = false, false, false;
+		local nameIsConform, guildIsConform, realmIsConform, notesIsConform = false, false, false, false;
 
 		if profile.characteristics and not Ellyb.Tables.isEmpty(profile.characteristics) then
 
@@ -383,12 +384,16 @@ local function getCharacterLines()
 				if safeMatch(unitName:lower(), nameSearch) then
 					nameIsConform = true;
 				end
-				if  unitRealm == Globals.player_realm_id or tContains(GetAutoCompleteRealms(), unitRealm) then
+				if unitRealm == Globals.player_realm_id or tContains(GetAutoCompleteRealms(), unitRealm) then
 					realmIsConform = true;
 				end
 				local characterData = AddOn_TotalRP3.Directory.getCharacterDataForCharacterId(unitID);
 				if characterData and characterData.guild and safeMatch(characterData.guild:lower(), guildSearch) then
 					guildIsConform = true;
+				end
+				local currentNotes = TRP3_API.profile.getPlayerCurrentProfile().notes or {};
+				if TRP3_Notes and TRP3_Notes[profileID] or currentNotes[profileID] then
+					notesIsConform = true;
 				end
 			end
 			local completeName = getCompleteName(profile.characteristics or {}, "", true);
@@ -399,8 +404,9 @@ local function getCharacterLines()
 			nameIsConform = nameIsConform or nameSearch:len() == 0;
 			guildIsConform = guildIsConform or guildSearch:len() == 0;
 			realmIsConform = realmIsConform or not realmOnly;
+			notesIsConform = notesIsConform or not notesOnly;
 
-			if nameIsConform and guildIsConform and realmIsConform then
+			if nameIsConform and guildIsConform and realmIsConform and notesIsConform then
 				tinsert(characterLines, {profileID, completeName, getRelationText(profileID), profile.time});
 			end
 
@@ -963,14 +969,17 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 		table.insert(widgetTab, widget);
 	end
 	TRP3_RegisterList.widgetTab = widgetTab;
+	TRP3_RegisterListFilterCharactNotes:SetChecked(false);
 	TRP3_RegisterListFilterCharactName:SetScript("OnEnterPressed", refreshList);
 	TRP3_RegisterListFilterCharactGuild:SetScript("OnEnterPressed", refreshList);
 	TRP3_RegisterListFilterCharactRealm:SetScript("OnClick", refreshList);
+	TRP3_RegisterListFilterCharactNotes:SetScript("OnClick", refreshList);
 	TRP3_RegisterListCharactFilterButton:SetScript("OnClick", function(_, button)
 		if button == "RightButton" then
 			TRP3_RegisterListFilterCharactName:SetText("");
 			TRP3_RegisterListFilterCharactGuild:SetText("");
 			TRP3_RegisterListFilterCharactRealm:SetChecked(true);
+			TRP3_RegisterListFilterCharactNotes:SetChecked(false);
 		end
 		refreshList();
 	end)
@@ -978,6 +987,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOAD, function()
 	TRP3_RegisterListFilterCharactNameText:SetText(loc.REG_LIST_NAME);
 	TRP3_RegisterListFilterCharactGuildText:SetText(loc.REG_LIST_GUILD);
 	TRP3_RegisterListFilterCharactRealmText:SetText(loc.REG_LIST_REALMONLY);
+	TRP3_RegisterListFilterCharactNotesText:SetText(loc.REG_LIST_NOTESONLY);
 	TRP3_RegisterListHeaderAddon:SetText(loc.REG_LIST_ADDON);
 	TRP3_API.ui.frame.setupEditBoxesNavigation({TRP3_RegisterListFilterCharactName, TRP3_RegisterListFilterCharactGuild});
 

--- a/totalRP3/modules/register/main/register_ui_list.xml
+++ b/totalRP3/modules/register/main/register_ui_list.xml
@@ -368,7 +368,7 @@
 
 					<!-- Characters filters -->
 					<Frame name="TRP3_RegisterListCharactFilter" parentKey="CharacterFilters" inherits="TRP3_FieldSetFrame">
-						<Size x="0" y="50" />
+						<Size x="0" y="65" />
 						<Anchors>
 							<Anchor point="BOTTOMLEFT" x="8" y="8" />
 							<Anchor point="BOTTOMRIGHT" x="-8" y="8" />
@@ -388,7 +388,12 @@
 							</EditBox>
 							<CheckButton name="TRP3_RegisterListFilterCharactRealm" inherits="TRP3_CheckBox" checked="true">
 								<Anchors>
-									<Anchor point="LEFT" x="15" y="0" relativePoint="RIGHT" relativeTo="TRP3_RegisterListFilterCharactGuild" />
+									<Anchor point="LEFT" x="15" y="12" relativePoint="RIGHT" relativeTo="TRP3_RegisterListFilterCharactGuild" />
+								</Anchors>
+							</CheckButton>
+							<CheckButton name="TRP3_RegisterListFilterCharactNotes" inherits="TRP3_CheckBox" checked="true">
+								<Anchors>
+									<Anchor point="LEFT" x="15" y="-12" relativePoint="RIGHT" relativeTo="TRP3_RegisterListFilterCharactGuild" />
 								</Anchors>
 							</CheckButton>
 							<Button name="TRP3_RegisterListCharactFilterButton" inherits="TRP3_SearchButton">
@@ -401,7 +406,7 @@
 
 					<!-- Companions filters -->
 					<Frame name="TRP3_RegisterListPetFilter" parentKey="CompanionFilters" inherits="TRP3_FieldSetFrame">
-						<Size x="0" y="50" />
+						<Size x="0" y="65" />
 						<Anchors>
 							<Anchor point="BOTTOMLEFT" x="8" y="8" />
 							<Anchor point="BOTTOMRIGHT" x="-8" y="8" />

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1283,6 +1283,7 @@ Since patch 8.0.1 you are able to report profiles that violates Blizzard's Terms
 	REG_PLAYER_NOTES_PROFILE_HELP = "These private notes are tied to your current profile and will change based on what profile you currently have active.",
 	REG_PLAYER_NOTES_ACCOUNT = "Common notes",
 	REG_PLAYER_NOTES_ACCOUNT_HELP = "These private notes are tied to your account and will be shared with all of your profiles.",
+	REG_REPORT_PLAYER_OPEN_URL_160 = [[If you wish to report %s's profile, you will need to open a ticket with Blizzard's support using the link below.]],
 };
 
 -- Use Ellyb to generate the Localization system

--- a/totalRP3/tools/Locale.lua
+++ b/totalRP3/tools/Locale.lua
@@ -1284,6 +1284,7 @@ Since patch 8.0.1 you are able to report profiles that violates Blizzard's Terms
 	REG_PLAYER_NOTES_ACCOUNT = "Common notes",
 	REG_PLAYER_NOTES_ACCOUNT_HELP = "These private notes are tied to your account and will be shared with all of your profiles.",
 	REG_REPORT_PLAYER_OPEN_URL_160 = [[If you wish to report %s's profile, you will need to open a ticket with Blizzard's support using the link below.]],
+	REG_LIST_NOTESONLY = "Has notes only",
 };
 
 -- Use Ellyb to generate the Localization system


### PR DESCRIPTION
- The notes tab width has been slightly reduced to prevent overlap with the report button
- The report buttons behaviour has been changed to both link to the support website. The date and time of receiving profile is still shown, so players can include that information in the ticket.
- The toolbar buttons check if the linked text frame exists (to stop a potential Lua error when clicking the toolbar after selecting Template 2 with no box added).
- The register has a checkbox to only display profiles with notes.